### PR TITLE
STORY-874: Curation: Add existing blocks to plugin

### DIFF
--- a/.github/workflows/coding-quality.yml
+++ b/.github/workflows/coding-quality.yml
@@ -12,3 +12,7 @@ on:
 jobs:
   code-quality:
     uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main
+    with:
+      php: 8.1
+      command: |
+        phpstan

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,3 +12,7 @@ on:
 jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
+    with:
+      php: 8.1
+      command: |
+        phpcs

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -37,6 +37,7 @@
     <properties>
       <property name="prefixes" type="array">
         <element value="alleyinteractive" />
+        <element value="alley" />
         <element value="wp_curate" />
       </property>
     </properties>

--- a/blocks/condition/block.json
+++ b/blocks/condition/block.json
@@ -16,8 +16,5 @@
   "usesContext": ["postId"],
   "providesContext": {
     "conditionResult": "conditionResult"
-  },
-  "supports": {
-    "inserter": true
   }
 }

--- a/blocks/condition/block.json
+++ b/blocks/condition/block.json
@@ -8,6 +8,11 @@
   "icon": "leftright",
   "description": "Renders blocks based on conditions.",
   "textdomain": "wp-curate",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
   "usesContext": ["postId"],
   "providesContext": {
     "conditionResult": "conditionResult"

--- a/blocks/condition/block.json
+++ b/blocks/condition/block.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/condition",
+  "version": "0.1.0",
+  "title": "Condition",
+  "category": "theme",
+  "icon": "leftright",
+  "description": "Renders blocks based on conditions.",
+  "textdomain": "wp-curate",
+  "usesContext": ["postId"],
+  "providesContext": {
+    "conditionResult": "conditionResult"
+  },
+  "supports": {
+    "inserter": true
+  }
+}

--- a/blocks/condition/edit.tsx
+++ b/blocks/condition/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/condition block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Block Name: Query Condition.
+ *
+ * @package wp-curate
+ */
+
+use wp_curate\Core\Global_Post_Query;
+use wp_curate\Core\Validator\Slug_Is_In_Category;
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_condition_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__,
+		[
+			'render_callback' => fn ( $attributes, $content ) => $content,
+		],
+	);
+}
+add_action( 'init', 'wp_curate_condition_block_init' );
+
+/**
+ * Evaluate the result of condition block attributes.
+ *
+ * @param array $parsed_block Parsed condition block.
+ * @param array $context      Available context.
+ * @return bool
+ */
+function wp_curate_condition_block_result( array $parsed_block, array $context ): bool {
+	global $wp_query;
+
+	$num_conditions = 0;
+	$num_true       = 0;
+
+	$conditions = [];
+
+	if ( isset( $parsed_block['attrs'] ) && is_array( $parsed_block['attrs'] ) ) {
+		$conditions = $parsed_block['attrs'];
+	}
+
+	if ( isset( $conditions['query'] ) && $wp_query instanceof WP_Query ) {
+		// Map `{"query": "is_home"} to {"query": {"is_home": true}}`.
+		if ( is_string( $conditions['query'] ) ) {
+			$conditions['query'] = array_fill_keys( (array) $conditions['query'], true );
+		}
+
+		foreach ( $conditions['query'] as $condition => $expect ) {
+			$num_conditions++;
+
+			switch ( true ) {
+				case 'is_singular' === $condition && ( is_string( $expect ) || is_array( $expect ) ):
+					$result = $wp_query->is_singular( $expect );
+					break;
+
+				case 'is_page' === $condition && ( is_string( $expect ) || is_array( $expect ) ):
+					$result = $wp_query->is_page( $expect );
+					break;
+
+				case 'is_tax' === $condition && ( is_string( $expect ) || is_array( $expect ) ):
+					$result = $wp_query->is_tax( $expect );
+					break;
+
+				case method_exists( $wp_query, $condition ):
+					$result = call_user_func( [ $wp_query, $condition ] ) === $expect;
+					break;
+
+				default:
+					$result = false;
+					break;
+			}
+
+			if ( false === $result ) {
+				break;
+			}
+
+			$num_true++;
+		}
+	}
+
+	/*
+	 * Checks the index of how many times the parent condition block has been rendered, like:
+	 *
+	 * {"index": {"===": 0}}
+	 * {"index": {">": 2}}
+	 * {"index": {">": 2, "<": 4}}
+	 *
+	 * @see \Alley\Validator\Comparison for the available operators.
+	 *
+	 * Note that this approach means that two identical conditions with two identical set of
+	 * child blocks will use the same counter.
+	 */
+	if ( isset( $conditions['index'] ) && is_array( $conditions['index'] ) ) {
+		$num_conditions++;
+
+		$validator = new \Laminas\Validator\ValidatorChain();
+
+		foreach ( $conditions['index'] as $operator => $compared ) {
+			try {
+				$validator->attach(
+					validator: new \Alley\Validator\Comparison(
+						[
+							'operator' => $operator,
+							'compared' => $compared,
+						],
+					),
+					breakChainOnFailure: true,
+				);
+			} catch ( Exception $exception ) {
+				// Nothing yet.
+				unset( $exception );
+			}
+		}
+
+		if ( count( $validator ) > 0 ) {
+			if ( $validator->isValid( wp_curate_current_counter_block() ) ) {
+				$num_true++;
+			}
+		}
+	}
+
+	if (
+		isset( $conditions['post'] )
+		&& isset( $context['postId'] )
+		&& is_numeric( $context['postId'] )
+		&& $context['postId'] > 0
+	) {
+		$conditions['post'] = (array) $conditions['post'];
+
+		foreach ( $conditions['post'] as $condition ) {
+			$num_conditions++;
+
+			if ( 'has_content' === $condition ) {
+				if ( '' !== get_the_content( null, null, $context['postId'] ) ) {
+					$num_true++;
+				}
+
+				continue;
+			}
+
+			/**
+			 * Filters the condition block's result for the given post condition.
+			 *
+			 * @param bool   $result    Condition result.
+			 * @param string $condition Condition name.
+			 * @param int    $post_id   Post ID.
+			 */
+			if ( true === apply_filters( 'wp_curate_condition_block_post_condition', false, $condition, $context['postId'] ) ) {
+				$num_true++;
+			}
+		}
+	}
+
+	if ( isset( $conditions['custom'] ) ) {
+		$conditions['custom'] = (array) $conditions['custom'];
+
+		foreach ( $conditions['custom'] as $condition ) {
+			$num_conditions++;
+
+			if ( 'is_column' === $condition ) {
+				$check = new Slug_Is_In_Category( new Global_Post_Query() );
+
+				if ( $check->isValid( 'category-column' ) || $check->isValid( 'category-hollyblog' ) ) {
+					$num_true++;
+				}
+			}
+		}
+	}
+
+	if ( isset( $conditions['condition'] ) ) {
+		$conditions['condition'] = (array) $conditions['condition'];
+
+		foreach ( $conditions['condition'] as $name ) {
+			$num_conditions++;
+
+			/**
+			 * Filters the condition block's result for the given condition.
+			 *
+			 * @param bool     $result   Condition result.
+			 * @param array    $context  Available context.
+			 * @param WP_Query $wp_query Global query object.
+			 */
+			$result = apply_filters( "wp_curate_condition_block_{$name}_condition", false, $context, $wp_query );
+
+			if ( true === $result ) {
+				$num_true++;
+			}
+		}
+	}
+
+	return $num_conditions > 0 && $num_conditions === $num_true;
+}

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -3,6 +3,9 @@
  * Block Name: Query Condition.
  *
  * @package wp-curate
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
  */
 
 use wp_curate\Core\Global_Post_Query;
@@ -76,7 +79,7 @@ function wp_curate_condition_block_result( array $parsed_block, array $context )
 					break;
 
 				case method_exists( $wp_query, $condition ) && is_callable( [ $wp_query, $condition ] ):
-					$result = call_user_func( [ $wp_query, $condition ] ) === $expect;
+					$result = call_user_func( [ $wp_query, $condition ] ) === $expect; // @phpstan-ignore-line
 					break;
 
 				default:

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -8,8 +8,8 @@
  * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
  */
 
-use wp_curate\Core\Global_Post_Query;
-use wp_curate\Core\Validator\Slug_Is_In_Category;
+use Alley\WP\WP_Curate\Global_Post_Query;
+use Alley\WP\WP_Curate\Validator\Slug_Is_In_Category;
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.

--- a/blocks/condition/index.php
+++ b/blocks/condition/index.php
@@ -41,7 +41,7 @@ add_action( 'init', 'wp_curate_condition_block_init' );
  *      index?: array<string, int>
  *   }
  * } $parsed_block Parsed condition block.
- * @param array{'postId'?: int} $context      Available context.
+ * @param array{'postId'?: int} $context Available context.
  * @return bool
  */
 function wp_curate_condition_block_result( array $parsed_block, array $context ): bool {

--- a/blocks/condition/index.scss
+++ b/blocks/condition/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/condition block.
+ */
+
+.wp-block-wp-curate-condition {
+  border: 1px dotted #f00;
+}

--- a/blocks/condition/index.ts
+++ b/blocks/condition/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/condition/style.scss
+++ b/blocks/condition/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/condition block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-condition {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/counter/block.json
+++ b/blocks/counter/block.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wp-curate/counter",
+	"version": "0.1.0",
+	"title": "Counter",
+	"category": "theme",
+	"icon": "editor-ol",
+	"description": "Count template iterations",
+	"textdomain": "wp-curate"
+}

--- a/blocks/counter/edit.tsx
+++ b/blocks/counter/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/counter block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/counter/index.php
+++ b/blocks/counter/index.php
@@ -39,9 +39,9 @@ add_action( 'init', 'wp_curate_counter_block_init' );
  * Inject a counter block into the post template block being rendered.
  *
  * @param WP_Block $parsed_block The block being rendered.
- * @return WP_Block
+ * @return array
  */
-function wp_curate_inject_counter_block( $parsed_block ): WP_Block {
+function wp_curate_inject_counter_block( $parsed_block ): array { // @phpstan-ignore-line
 	global $wp_curate_template_stack;
 
 	if ( isset( $parsed_block['blockName'] ) && 'core/post-template' === $parsed_block['blockName'] ) {
@@ -63,7 +63,7 @@ function wp_curate_inject_counter_block( $parsed_block ): WP_Block {
 		array_unshift( $parsed_block['innerContent'], null );
 	}
 
-	return $parsed_block;
+	return $parsed_block; // @phpstan-ignore-line
 }
 add_filter( 'render_block_data', 'wp_curate_inject_counter_block', 100 );
 

--- a/blocks/counter/index.php
+++ b/blocks/counter/index.php
@@ -8,7 +8,7 @@
  * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
  */
 
-use WP_Curate\Core\Block;
+use Alley\WP\WP_Curate\Block;
 
 use function Alley\WP\add_filter_side_effect;
 use function Alley\WP\match_block;

--- a/blocks/counter/index.php
+++ b/blocks/counter/index.php
@@ -38,16 +38,24 @@ add_action( 'init', 'wp_curate_counter_block_init' );
 /**
  * Inject a counter block into the post template block being rendered.
  *
- * @param WP_Block $parsed_block The block being rendered.
- * @return array
+ * @param array{
+ *   blockName?: string,
+ *   innerBlocks?: mixed[],
+ *   innerContent?: mixed[],
+ * } $parsed_block The block being rendered.
+ * @return array{
+ *   blockName?: string,
+ *   innerBlocks?: mixed[],
+ *   innerContent?: mixed[],
+ * }
  */
-function wp_curate_inject_counter_block( $parsed_block ): array { // @phpstan-ignore-line
+function wp_curate_inject_counter_block( array $parsed_block ): array {
 	global $wp_curate_template_stack;
 
 	if ( isset( $parsed_block['blockName'] ) && 'core/post-template' === $parsed_block['blockName'] ) {
 		$wp_curate_template_stack[] = -1;
 
-		if ( ! isset( $parsed_block['innerBlocks'] ) || ! is_array( $parsed_block['innerBlocks'] ) ) {
+		if ( ! isset( $parsed_block['innerBlocks'] ) || ! is_array( $parsed_block['innerBlocks'] ) ) { // @phpstan-ignore-line
 			$parsed_block['innerBlocks'] = [];
 		}
 
@@ -56,14 +64,14 @@ function wp_curate_inject_counter_block( $parsed_block ): array { // @phpstan-ig
 			Block::create( 'wp-curate/counter' )->parsed_block(),
 		);
 
-		if ( ! isset( $parsed_block['innerContent'] ) || ! is_array( $parsed_block['innerContent'] ) ) {
+		if ( ! isset( $parsed_block['innerContent'] ) || ! is_array( $parsed_block['innerContent'] ) ) { // @phpstan-ignore-line
 			$parsed_block['innerContent'] = [];
 		}
 
 		array_unshift( $parsed_block['innerContent'], null );
 	}
 
-	return $parsed_block; // @phpstan-ignore-line
+	return $parsed_block;
 }
 add_filter( 'render_block_data', 'wp_curate_inject_counter_block', 100 );
 

--- a/blocks/counter/index.php
+++ b/blocks/counter/index.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Block Name: Counter.
+ *
+ * @package wp-curate
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
+ */
+
+use WP_Curate\Core\Block;
+
+use function Alley\WP\add_filter_side_effect;
+use function Alley\WP\match_block;
+
+global $wp_curate_template_stack;
+
+$wp_curate_template_stack = [];
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_counter_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__,
+		[
+			'render_callback' => 'wp_curate_render_counter_block',
+		],
+	);
+}
+add_action( 'init', 'wp_curate_counter_block_init' );
+
+/**
+ * Inject a counter block into the post template block being rendered.
+ *
+ * @param WP_Block $parsed_block The block being rendered.
+ * @return WP_Block
+ */
+function wp_curate_inject_counter_block( $parsed_block ): WP_Block {
+	global $wp_curate_template_stack;
+
+	if ( isset( $parsed_block['blockName'] ) && 'core/post-template' === $parsed_block['blockName'] ) {
+		$wp_curate_template_stack[] = -1;
+
+		if ( ! isset( $parsed_block['innerBlocks'] ) || ! is_array( $parsed_block['innerBlocks'] ) ) {
+			$parsed_block['innerBlocks'] = [];
+		}
+
+		array_unshift(
+			$parsed_block['innerBlocks'],
+			Block::create( 'wp-curate/counter' )->parsed_block(),
+		);
+
+		if ( ! isset( $parsed_block['innerContent'] ) || ! is_array( $parsed_block['innerContent'] ) ) {
+			$parsed_block['innerContent'] = [];
+		}
+
+		array_unshift( $parsed_block['innerContent'], null );
+	}
+
+	return $parsed_block;
+}
+add_filter( 'render_block_data', 'wp_curate_inject_counter_block', 100 );
+
+/**
+ * When the counter block renders, increase the count of the current template's iterations.
+ *
+ * @param array<mixed> $attributes Block attributes.
+ * @param string       $content    Block default content.
+ * @param WP_Block     $block      Block instance.
+ * @return string Block output.
+ */
+function wp_curate_render_counter_block( $attributes, $content, $block ): string {
+	global $wp_curate_template_stack;
+
+	if ( is_array( $wp_curate_template_stack ) && count( $wp_curate_template_stack ) > 0 ) {
+		$last                       = array_pop( $wp_curate_template_stack );
+		$wp_curate_template_stack[] = $last + 1;
+	}
+
+	return $content;
+}
+
+/**
+ * Current iteration of the current template block.
+ *
+ * @return int
+ */
+function wp_curate_current_counter_block(): int {
+	global $wp_curate_template_stack;
+
+	$current = -1;
+
+	if ( is_array( $wp_curate_template_stack ) && count( $wp_curate_template_stack ) > 0 ) {
+		$key     = array_key_last( $wp_curate_template_stack );
+		$current = $wp_curate_template_stack[ $key ];
+	}
+
+	return $current;
+}
+
+/**
+ * Remove the last iteration count from the top of the stack after the template block renders.
+ *
+ * @param string $block_content The block content.
+ * @param array{
+ *   name: string,
+ *   attrs: array<string, mixed>,
+ *   innerBlocks: array<mixed>,
+ *   innerHTML: string,
+ *   innerContent: array<string>,
+ * } $block The full block, including name and attributes.
+ */
+function wp_curate_after_counter_block( $block_content, $block ): void {
+	global $wp_curate_template_stack;
+
+	if ( is_array( $wp_curate_template_stack ) && count( $wp_curate_template_stack ) > 0 ) {
+		$inner_counter = match_block(
+			$block,
+			[
+				'name'    => 'wp-curate/counter',
+				'flatten' => false,
+			],
+		);
+
+		// Pop only if there was a counter in this template.
+		if ( null !== $inner_counter ) {
+			array_pop( $wp_curate_template_stack );
+		}
+	}
+}
+add_filter_side_effect( 'render_block_core/post-template', 'wp_curate_after_counter_block', 10, 2 );

--- a/blocks/counter/index.scss
+++ b/blocks/counter/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/counter block.
+ */
+
+.wp-block-wp-curate-counter {
+  border: 1px dotted #f00;
+}

--- a/blocks/counter/index.ts
+++ b/blocks/counter/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/counter/style.scss
+++ b/blocks/counter/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/counter block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-counter {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/is-false/block.json
+++ b/blocks/is-false/block.json
@@ -13,8 +13,5 @@
 	"style": [
 		"file:style-index.css"
 	],
-  "usesContext": ["conditionResult"],
-  "supports": {
-    "inserter": true
-  }
+  "usesContext": ["conditionResult"]
 }

--- a/blocks/is-false/block.json
+++ b/blocks/is-false/block.json
@@ -8,10 +8,10 @@
   "icon": "allow-right",
   "description": "Displays when the condition is false.",
   "textdomain": "wp-curate",
-	"editorScript": "file:index.ts",
-	"editorStyle": "file:index.css",
-	"style": [
-		"file:style-index.css"
-	],
+  "editorScript": "file:index.ts",
+  "editorStyle": "file:index.css",
+  "style": [
+    "file:style-index.css"
+  ],
   "usesContext": ["conditionResult"]
 }

--- a/blocks/is-false/block.json
+++ b/blocks/is-false/block.json
@@ -8,6 +8,11 @@
   "icon": "allow-right",
   "description": "Displays when the condition is false.",
   "textdomain": "wp-curate",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
   "usesContext": ["conditionResult"],
   "supports": {
     "inserter": true

--- a/blocks/is-false/block.json
+++ b/blocks/is-false/block.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/is-false",
+  "version": "0.1.0",
+  "title": "Condition Is False",
+  "category": "theme",
+  "icon": "allow-right",
+  "description": "Displays when the condition is false.",
+  "textdomain": "wp-curate",
+  "usesContext": ["conditionResult"],
+  "supports": {
+    "inserter": true
+  }
+}

--- a/blocks/is-false/edit.tsx
+++ b/blocks/is-false/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/is-false block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/is-false/index.php
+++ b/blocks/is-false/index.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Block Name: Displays when the condition is false..
+ *
+ * @package wp-curate
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_is_false_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__,
+		[
+			'render_callback' => fn ( $attributes, $content ) => $content,
+		],
+	);
+}
+add_action( 'init', 'wp_curate_is_false_block_init' );
+
+/**
+ * Short-circuit the display of blocks inside if the outer condition isn't false.
+ *
+ * @param string|null   $pre_render   The pre-rendered content. Default null.
+ * @param array         $parsed_block The block being rendered.
+ * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+ */
+function wp_curate_pre_render_is_false_block( $pre_render, $parsed_block, $parent_block ) {
+	/*
+	 * Previously, the condition block added 'conditionResult' as context to this block. However,
+	 * limitations in the context API meant that the context didn't get passed to child blocks when
+	 * the condition block was itself a child block. We now pass the condition block back to a
+	 * separate function that lives outside the context API and evaluates the result.
+	 */
+	if (
+		isset( $parsed_block['blockName'] )
+		&& 'wp-curate/is-false' === $parsed_block['blockName']
+		&& $parent_block instanceof WP_Block
+		&& isset( $parent_block->parsed_block['blockName'] )
+		&& 'wp-curate/condition' === $parent_block->parsed_block['blockName']
+	) {
+		$context = [];
+
+		if ( isset( $parent_block->context['postId'] ) ) {
+			$context['postId'] = $parent_block->context['postId'];
+		}
+
+		$result = wp_curate_condition_block_result( $parent_block->parsed_block, $context );
+
+		if ( false !== $result ) {
+			$pre_render = '';
+		}
+	}
+
+	return $pre_render;
+}
+add_filter( 'pre_render_block', 'wp_curate_pre_render_is_false_block', 10, 3 );

--- a/blocks/is-false/index.php
+++ b/blocks/is-false/index.php
@@ -27,10 +27,10 @@ add_action( 'init', 'wp_curate_is_false_block_init' );
  * Short-circuit the display of blocks inside if the outer condition isn't false.
  *
  * @param string|null   $pre_render   The pre-rendered content. Default null.
- * @param array         $parsed_block The block being rendered.
+ * @param WP_Block      $parsed_block The block being rendered.
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
-function wp_curate_pre_render_is_false_block( $pre_render, $parsed_block, $parent_block ) {
+function wp_curate_pre_render_is_false_block( $pre_render, $parsed_block, $parent_block ): string|null {
 	/*
 	 * Previously, the condition block added 'conditionResult' as context to this block. However,
 	 * limitations in the context API meant that the context didn't get passed to child blocks when

--- a/blocks/is-false/index.scss
+++ b/blocks/is-false/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/is-false block.
+ */
+
+.wp-block-wp-curate-is-false {
+  border: 1px dotted #f00;
+}

--- a/blocks/is-false/index.ts
+++ b/blocks/is-false/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/is-false/style.scss
+++ b/blocks/is-false/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/is-false block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-is-false {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/is-true/block.json
+++ b/blocks/is-true/block.json
@@ -13,8 +13,5 @@
 	"style": [
 		"file:style-index.css"
 	],
-  "usesContext": ["conditionResult"],
-  "supports": {
-    "inserter": true
-  }
+  "usesContext": ["conditionResult"]
 }

--- a/blocks/is-true/block.json
+++ b/blocks/is-true/block.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/is-true",
+  "version": "0.1.0",
+  "title": "Condition Is True",
+  "category": "theme",
+  "icon": "arrow-left",
+  "description": "Displays when the condition is true.",
+  "textdomain": "wp-curate",
+  "usesContext": ["conditionResult"],
+  "supports": {
+    "inserter": true
+  }
+}

--- a/blocks/is-true/block.json
+++ b/blocks/is-true/block.json
@@ -8,6 +8,11 @@
   "icon": "arrow-left",
   "description": "Displays when the condition is true.",
   "textdomain": "wp-curate",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
   "usesContext": ["conditionResult"],
   "supports": {
     "inserter": true

--- a/blocks/is-true/block.json
+++ b/blocks/is-true/block.json
@@ -8,10 +8,10 @@
   "icon": "arrow-left",
   "description": "Displays when the condition is true.",
   "textdomain": "wp-curate",
-	"editorScript": "file:index.ts",
-	"editorStyle": "file:index.css",
-	"style": [
-		"file:style-index.css"
-	],
+  "editorScript": "file:index.ts",
+  "editorStyle": "file:index.css",
+  "style": [
+    "file:style-index.css"
+  ],
   "usesContext": ["conditionResult"]
 }

--- a/blocks/is-true/edit.tsx
+++ b/blocks/is-true/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/is-true block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/is-true/index.php
+++ b/blocks/is-true/index.php
@@ -27,10 +27,10 @@ add_action( 'init', 'wp_curate_is_true_block_init' );
  * Short-circuit the display of blocks inside if the outer condition isn't true.
  *
  * @param string|null   $pre_render   The pre-rendered content. Default null.
- * @param array         $parsed_block The block being rendered.
+ * @param WP_Block      $parsed_block The block being rendered.
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
  */
-function wp_curate_pre_render_is_true_block( $pre_render, $parsed_block, $parent_block ) {
+function wp_curate_pre_render_is_true_block( $pre_render, $parsed_block, $parent_block ): string|null {
 	/*
 	 * Previously, the condition block added 'conditionResult' as context to this block. However,
 	 * limitations in the context API meant that the context didn't get passed to child blocks when

--- a/blocks/is-true/index.php
+++ b/blocks/is-true/index.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Block Name: Is True.
+ *
+ * @package wp-curate
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_is_true_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__,
+		[
+			'render_callback' => fn ( $attributes, $content ) => $content,
+		],
+	);
+}
+add_action( 'init', 'wp_curate_is_true_block_init' );
+
+/**
+ * Short-circuit the display of blocks inside if the outer condition isn't true.
+ *
+ * @param string|null   $pre_render   The pre-rendered content. Default null.
+ * @param array         $parsed_block The block being rendered.
+ * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+ */
+function wp_curate_pre_render_is_true_block( $pre_render, $parsed_block, $parent_block ) {
+	/*
+	 * Previously, the condition block added 'conditionResult' as context to this block. However,
+	 * limitations in the context API meant that the context didn't get passed to child blocks when
+	 * the condition block was itself a child block. We now pass the condition block back to a
+	 * separate function that lives outside the context API and evaluates the result.
+	 */
+	if (
+		isset( $parsed_block['blockName'] )
+		&& 'wp-curate/is-true' === $parsed_block['blockName']
+		&& $parent_block instanceof WP_Block
+		&& isset( $parent_block->parsed_block['blockName'] )
+		&& 'wp-curate/condition' === $parent_block->parsed_block['blockName']
+	) {
+		$context = [];
+
+		if ( isset( $parent_block->context['postId'] ) ) {
+			$context['postId'] = $parent_block->context['postId'];
+		}
+
+		$result = wp_curate_condition_block_result( $parent_block->parsed_block, $context );
+
+		if ( true !== $result ) {
+			$pre_render = '';
+		}
+	}
+
+	return $pre_render;
+}
+add_filter( 'pre_render_block', 'wp_curate_pre_render_is_true_block', 10, 3 );

--- a/blocks/is-true/index.scss
+++ b/blocks/is-true/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/is-true block.
+ */
+
+.wp-block-wp-curate-is-true {
+  border: 1px dotted #f00;
+}

--- a/blocks/is-true/index.ts
+++ b/blocks/is-true/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/is-true/style.scss
+++ b/blocks/is-true/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/is-true block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-is-true {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/query-heading/block.json
+++ b/blocks/query-heading/block.json
@@ -1,20 +1,20 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "wp-curate/query-heading",
-	"version": "0.1.0",
-	"title": "Query Heading",
-	"category": "theme",
-	"icon": "heading",
-	"description": "Display heading for a custom query",
-	"textdomain": "wp-curate",
-	"editorScript": "file:index.ts",
-	"editorStyle": "file:index.css",
-	"style": [
-		"file:style-index.css"
-	],
-	"render": "file:render.php",
-	"usesContext": [
-		"heading"
-	]
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/query-heading",
+  "version": "0.1.0",
+  "title": "Query Heading",
+  "category": "theme",
+  "icon": "heading",
+  "description": "Display heading for a custom query",
+  "textdomain": "wp-curate",
+  "editorScript": "file:index.ts",
+  "editorStyle": "file:index.css",
+  "style": [
+    "file:style-index.css"
+  ],
+  "render": "file:render.php",
+  "usesContext": [
+    "heading"
+  ]
 }

--- a/blocks/query-heading/block.json
+++ b/blocks/query-heading/block.json
@@ -16,8 +16,5 @@
 	"render": "file:render.php",
 	"usesContext": [
 		"heading"
-	],
-	"supports": {
-		"inserter": true
-	}
+	]
 }

--- a/blocks/query-heading/block.json
+++ b/blocks/query-heading/block.json
@@ -8,9 +8,16 @@
 	"icon": "heading",
 	"description": "Display heading for a custom query",
 	"textdomain": "wp-curate",
-  "render": "file:render.php",
-  "usesContext": ["heading"],
-  "supports": {
-    "inserter": true
-  }
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
+	"render": "file:render.php",
+	"usesContext": [
+		"heading"
+	],
+	"supports": {
+		"inserter": true
+	}
 }

--- a/blocks/query-heading/block.json
+++ b/blocks/query-heading/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wp-curate/query-heading",
+	"version": "0.1.0",
+	"title": "Query Heading",
+	"category": "theme",
+	"icon": "heading",
+	"description": "Display heading for a custom query",
+	"textdomain": "wp-curate",
+  "render": "file:render.php",
+  "usesContext": ["heading"],
+  "supports": {
+    "inserter": true
+  }
+}

--- a/blocks/query-heading/edit.tsx
+++ b/blocks/query-heading/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/query block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/query-heading/index.php
+++ b/blocks/query-heading/index.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Block Name: Display heading for a custom query.
+ *
+ * @package wp-curate
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_query_heading_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__
+	);
+}
+add_action( 'init', 'wp_curate_query_heading_block_init' );

--- a/blocks/query-heading/index.scss
+++ b/blocks/query-heading/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/query-heading block.
+ */
+
+.wp-block-wp-curate-query-heading {
+  border: 1px dotted #f00;
+}

--- a/blocks/query-heading/index.ts
+++ b/blocks/query-heading/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/query-heading/render.php
+++ b/blocks/query-heading/render.php
@@ -2,9 +2,9 @@
 /**
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @var array    $attributes The array of attributes for this block.
- * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
- * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.
+ * @var array<mixed> $attributes The array of attributes for this block.
+ * @var string       $content    Rendered block output. ie. <InnerBlocks.Content />.
+ * @var WP_Block     $block      The instance of the WP_Block class that represents the block being rendered.
  *
  * @package wp-curate
  */

--- a/blocks/query-heading/render.php
+++ b/blocks/query-heading/render.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * All of the parameters passed to the function where this file is being required are accessible in this scope:
+ *
+ * @var array    $attributes The array of attributes for this block.
+ * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
+ * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.
+ *
+ * @package wp-curate
+ */
+
+$wp_curate_heading = '';
+
+if ( isset( $block->context['heading']['source'] ) ) :
+	if ( 'custom' === $block->context['heading']['source'] && isset( $block->context['heading']['custom'] ) ) :
+		$wp_curate_heading = $block->context['heading']['custom'];
+	endif;
+
+	if (
+		'termId' === $block->context['heading']['source']
+		&& isset( $block->context['heading']['termId'], $block->context['heading']['taxonomy'] )
+	) :
+		$wp_curate_term = get_term( $block->context['heading']['termId'], $block->context['heading']['taxonomy'] );
+
+		if ( $wp_curate_term instanceof WP_Term ) :
+			$wp_curate_heading = html_entity_decode( $wp_curate_term->name );
+		endif;
+	endif;
+
+	if ( is_string( $wp_curate_heading ) && '' !== $wp_curate_heading ) :
+		?>
+			<h2 <?php echo wp_kses_data( get_block_wrapper_attributes( [ 'class' => 'wp-block-heading' ] ) ); ?>>
+				<?php echo esc_html( $wp_curate_heading ); ?>
+			</h2>
+		<?php
+	endif;
+endif;

--- a/blocks/query-heading/style.scss
+++ b/blocks/query-heading/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/query-heading block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-query-heading {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/query-link/block.json
+++ b/blocks/query-link/block.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wp-curate/query-link",
+	"version": "0.1.0",
+	"title": "Query Link",
+	"category": "theme",
+	"icon": "admin-links",
+	"description": "Display \"See All\" link for a custom query.",
+	"textdomain": "wp-curate",
+  "usesContext": ["curation"],
+	"render": "file:render.php"
+}

--- a/blocks/query-link/block.json
+++ b/blocks/query-link/block.json
@@ -8,6 +8,13 @@
 	"icon": "admin-links",
 	"description": "Display \"See All\" link for a custom query.",
 	"textdomain": "wp-curate",
-  "usesContext": ["curation"],
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
+	"usesContext": [
+		"curation"
+	],
 	"render": "file:render.php"
 }

--- a/blocks/query-link/block.json
+++ b/blocks/query-link/block.json
@@ -1,20 +1,20 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "wp-curate/query-link",
-	"version": "0.1.0",
-	"title": "Query Link",
-	"category": "theme",
-	"icon": "admin-links",
-	"description": "Display \"See All\" link for a custom query.",
-	"textdomain": "wp-curate",
-	"editorScript": "file:index.ts",
-	"editorStyle": "file:index.css",
-	"style": [
-		"file:style-index.css"
-	],
-	"usesContext": [
-		"curation"
-	],
-	"render": "file:render.php"
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/query-link",
+  "version": "0.1.0",
+  "title": "Query Link",
+  "category": "theme",
+  "icon": "admin-links",
+  "description": "Display \"See All\" link for a custom query.",
+  "textdomain": "wp-curate",
+  "editorScript": "file:index.ts",
+  "editorStyle": "file:index.css",
+  "style": [
+    "file:style-index.css"
+  ],
+  "usesContext": [
+    "curation"
+  ],
+  "render": "file:render.php"
 }

--- a/blocks/query-link/edit.tsx
+++ b/blocks/query-link/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/query-link block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/query-link/index.php
+++ b/blocks/query-link/index.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Block Name: Query Link.
+ *
+ * @package wp-curate
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_query_link_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__
+	);
+}
+add_action( 'init', 'wp_curate_query_link_block_init' );

--- a/blocks/query-link/index.scss
+++ b/blocks/query-link/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/query-link block.
+ */
+
+.wp-block-wp-curate-query-link {
+  border: 1px dotted #f00;
+}

--- a/blocks/query-link/index.ts
+++ b/blocks/query-link/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/query-link/render.php
+++ b/blocks/query-link/render.php
@@ -2,14 +2,14 @@
 /**
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @var array    $attributes The array of attributes for this block.
- * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
- * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.
+ * @var array<mixed> $attributes The array of attributes for this block.
+ * @var string       $content    Rendered block output. ie. <InnerBlocks.Content />.
+ * @var WP_Block     $block      The instance of the WP_Block class that represents the block being rendered.
  *
  * @package wp-curate
  */
 
-use wp_curate\Core\WP_Utils;
+use WP_Curate\Core\WP_Utils;
 
 $wp_curate_link = '';
 

--- a/blocks/query-link/render.php
+++ b/blocks/query-link/render.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * All of the parameters passed to the function where this file is being required are accessible in this scope:
+ *
+ * @var array    $attributes The array of attributes for this block.
+ * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
+ * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.
+ *
+ * @package wp-curate
+ */
+
+use wp_curate\Core\WP_Utils;
+
+$wp_curate_link = '';
+
+if ( isset( $block->context['curation']['provider'] ) && is_string( $block->context['curation']['provider'] ) ) :
+	$wp_curate_provider = $block->context['curation']['provider'];
+
+	if ( taxonomy_exists( $wp_curate_provider ) && isset( $block->context['curation'][ $wp_curate_provider ] ) ) :
+		$wp_curate_term = get_term( $block->context['curation'][ $wp_curate_provider ], $wp_curate_provider );
+
+		if ( WP_Utils::is_wp_term( $wp_curate_term ) ) :
+			$wp_curate_term_link = get_term_link( $wp_curate_term, $wp_curate_provider );
+
+			if ( is_string( $wp_curate_term_link ) ) {
+				$wp_curate_link = $wp_curate_term_link;
+			}
+		endif;
+	endif;
+endif;
+
+if ( strlen( $wp_curate_link ) > 0 ) :
+	?>
+	<a
+		href="<?php echo esc_url( $wp_curate_link ); ?>"
+		<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	>
+		<?php echo esc_html( $content ); ?>
+	</a>
+	<?php
+endif;

--- a/blocks/query-link/render.php
+++ b/blocks/query-link/render.php
@@ -20,7 +20,7 @@ if ( isset( $block->context['curation']['provider'] ) && is_string( $block->cont
 		$wp_curate_term = get_term( $block->context['curation'][ $wp_curate_provider ], $wp_curate_provider );
 
 		if ( WP_Utils::is_wp_term( $wp_curate_term ) ) :
-			$wp_curate_term_link = get_term_link( $wp_curate_term, $wp_curate_provider );
+			$wp_curate_term_link = get_term_link( $wp_curate_term, $wp_curate_provider ); // @phpstan-ignore-line
 
 			if ( is_string( $wp_curate_term_link ) ) {
 				$wp_curate_link = $wp_curate_term_link;

--- a/blocks/query-link/render.php
+++ b/blocks/query-link/render.php
@@ -9,7 +9,7 @@
  * @package wp-curate
  */
 
-use WP_Curate\Core\WP_Utils;
+use Alley\WP\WP_Curate\WP_Utils;
 
 $wp_curate_link = '';
 

--- a/blocks/query-link/style.scss
+++ b/blocks/query-link/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/query-link block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-query-link {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/query-template/block.json
+++ b/blocks/query-template/block.json
@@ -1,22 +1,24 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "wp-curate/query-template",
-	"version": "0.1.0",
-	"title": "Query Template",
-	"category": "theme",
-	"icon": "filter",
-	"description": "Contains the block elements used to render a custom query",
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/query-template",
+  "version": "0.1.0",
+  "title": "Query Template",
+  "category": "theme",
+  "icon": "filter",
+  "description": "Contains the block elements used to render a custom query",
   "textdomain": "wp-curate",
-	"editorScript": "file:index.ts",
-	"editorStyle": "file:index.css",
-	"style": [
-		"file:style-index.css"
-	],
+  "editorScript": "file:index.ts",
+  "editorStyle": "file:index.css",
+  "style": [
+    "file:style-index.css"
+  ],
   "attributes": {
     "name": {
       "type": "string"
     }
   },
-  "usesContext": ["queries"]
+  "usesContext": [
+    "queries"
+  ]
 }

--- a/blocks/query-template/block.json
+++ b/blocks/query-template/block.json
@@ -18,8 +18,5 @@
       "type": "string"
     }
   },
-  "usesContext": ["queries"],
-  "supports": {
-    "inserter": true
-  }
+  "usesContext": ["queries"]
 }

--- a/blocks/query-template/block.json
+++ b/blocks/query-template/block.json
@@ -8,6 +8,11 @@
 	"icon": "filter",
 	"description": "Contains the block elements used to render a custom query",
   "textdomain": "wp-curate",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
   "attributes": {
     "name": {
       "type": "string"

--- a/blocks/query-template/block.json
+++ b/blocks/query-template/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wp-curate/query-template",
+	"version": "0.1.0",
+	"title": "Query Template",
+	"category": "theme",
+	"icon": "filter",
+	"description": "Contains the block elements used to render a custom query",
+  "textdomain": "wp-curate",
+  "attributes": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "usesContext": ["queries"],
+  "supports": {
+    "inserter": true
+  }
+}

--- a/blocks/query-template/edit.tsx
+++ b/blocks/query-template/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/query-template block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/query-template/index.php
+++ b/blocks/query-template/index.php
@@ -27,9 +27,9 @@ add_action( 'init', 'wp_curate_query_template_block_init' );
 /**
  * Renders the `wp-curate/query-template` block on the server.
  *
- * @param array    $attributes Block attributes.
- * @param string   $content    Block default content.
- * @param WP_Block $block      Block instance.
+ * @param array<mixed> $attributes Block attributes.
+ * @param string       $content    Block default content.
+ * @param WP_Block     $block      Block instance.
  * @return string Block output.
  */
 function wp_curate_render_query_template_block( $attributes, $content, $block ): string {

--- a/blocks/query-template/index.php
+++ b/blocks/query-template/index.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Block Name: Query Template.
+ *
+ * @package wp-curate
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_query_template_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__,
+		[
+			'render_callback'   => 'wp_curate_render_query_template_block',
+			'skip_inner_blocks' => true,
+		],
+	);
+}
+add_action( 'init', 'wp_curate_query_template_block_init' );
+
+/**
+ * Renders the `wp-curate/query-template` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ * @return string Block output.
+ */
+function wp_curate_render_query_template_block( $attributes, $content, $block ): string {
+	$content = '';
+
+	if ( isset( $block->context['queries'] ) && is_array( $block->context['queries'] ) ) {
+		foreach ( $block->context['queries'] as $query ) {
+			if ( is_array( $query ) ) {
+				$block_instance              = $block->parsed_block;
+				$block_instance['blockName'] = 'wp-curate/query';
+				$block_instance['attrs']     = $query;
+
+				$content .= render_block( $block_instance );
+			}
+		}
+	}
+
+	return $content;
+}

--- a/blocks/query-template/index.scss
+++ b/blocks/query-template/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/query-template block.
+ */
+
+.wp-block-wp-curate-query-template {
+  border: 1px dotted #f00;
+}

--- a/blocks/query-template/index.ts
+++ b/blocks/query-template/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/query-template/style.scss
+++ b/blocks/query-template/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/query-template block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-query-template {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -8,6 +8,11 @@
   "icon": "filter",
   "description": "Custom queries for WP Curate",
   "textdomain": "wp-curate",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
   "providesContext": {
     "query": "query",
     "displayLayout": "displayLayout",
@@ -18,8 +23,5 @@
     "name": {
       "type": "string"
     }
-  },
-  "supports": {
-    "inserter": true
   }
 }

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -8,11 +8,11 @@
   "icon": "filter",
   "description": "Custom queries for WP Curate",
   "textdomain": "wp-curate",
-	"editorScript": "file:index.ts",
-	"editorStyle": "file:index.css",
-	"style": [
-		"file:style-index.css"
-	],
+  "editorScript": "file:index.ts",
+  "editorStyle": "file:index.css",
+  "style": [
+    "file:style-index.css"
+  ],
   "providesContext": {
     "query": "query",
     "displayLayout": "displayLayout",

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "wp-curate/query",
+  "version": "0.1.0",
+  "title": "Query",
+  "category": "theme",
+  "icon": "filter",
+  "description": "Custom queries for WP Curate",
+  "textdomain": "wp-curate",
+  "providesContext": {
+    "query": "query",
+    "displayLayout": "displayLayout",
+    "heading": "heading",
+    "curation": "curation"
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "supports": {
+    "inserter": true
+  }
+}

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './index.scss';
+
+/**
+ * The wp-curate/query block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit() {
+  return (
+    <p {...useBlockProps()}>
+      { __('Block Title - hello from the editor!') }
+    </p>
+  );
+}

--- a/blocks/query/index.php
+++ b/blocks/query/index.php
@@ -28,11 +28,11 @@ add_action( 'init', 'wp_curate_query_block_init' );
 /**
  * Renders the `wp-curate/query` block on the server.
  *
- * @param array  $attributes Block attributes.
- * @param string $content    Block default content.
+ * @param array<mixed> $attributes Block attributes.
+ * @param string       $content    Block default content.
  * @return string Block output.
  */
-function wp_curate_render_query_block( $attributes, $content ) {
+function wp_curate_render_query_block( $attributes, $content ): string {
 	$proc = new WP_HTML_Tag_Processor( $content );
 
 	/*
@@ -44,17 +44,18 @@ function wp_curate_render_query_block( $attributes, $content ) {
 	 * available because the post template inner block needs to render for us to know whether there
 	 * are any posts to begin with.
 	 */
-	return $proc->next_tag( 'ul' ) === true || $proc->next_tag( 'ol' ) === true ? $content : '';
+	return $proc->next_tag( [ 'tag_name' => 'ul' ] ) === true || $proc->next_tag( [ 'tag_name' => 'ol' ] ) === true ? $content : '';
 }
 
 /**
  * Provide the 'query' as context to a rendered block.
  *
- * @param array         $context      Default context.
- * @param array         $parsed_block Block being rendered, filtered by `render_block_data`.
+ * @param array<mixed>  $context      Default context.
+ * @param WP_Block      $parsed_block Block being rendered, filtered by `render_block_data`.
  * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+ * @return array<mixed> Context.
  */
-function wp_curate_query_block_context( $context, $parsed_block, $parent_block ) {
+function wp_curate_query_block_context( $context, $parsed_block, $parent_block ): array {
 	if (
 		! isset( $parsed_block['blockName'], $parsed_block['attrs'] )
 		|| 'wp-curate/query' !== $parsed_block['blockName']
@@ -62,6 +63,7 @@ function wp_curate_query_block_context( $context, $parsed_block, $parent_block )
 		return $context;
 	}
 
+	/*
 	$attributes = $parsed_block['attrs'];
 
 	if ( isset( $attributes['name'] ) ) {
@@ -79,6 +81,7 @@ function wp_curate_query_block_context( $context, $parsed_block, $parent_block )
 			}
 		}
 	}
+	*/
 
 	return $context;
 }

--- a/blocks/query/index.php
+++ b/blocks/query/index.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Block Name: Query.
+ *
+ * @package wp-curate
+ */
+
+use Byline_Manager\Models\Profile;
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function wp_curate_query_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__,
+		[
+			'render_callback' => 'wp_curate_render_query_block',
+		],
+	);
+}
+add_action( 'init', 'wp_curate_query_block_init' );
+
+/**
+ * Renders the `wp-curate/query` block on the server.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block default content.
+ * @return string Block output.
+ */
+function wp_curate_render_query_block( $attributes, $content ) {
+	$proc = new WP_HTML_Tag_Processor( $content );
+
+	/*
+	 * If a query returns no posts -- denoted by the absence of a list in the content -- don't
+	 * show any of the inner content.
+	 *
+	 * This approach is not great because the inner blocks will have been rendered already and their
+	 * scripts and styles will have been enqueued, but it's not clear what other options are
+	 * available because the post template inner block needs to render for us to know whether there
+	 * are any posts to begin with.
+	 */
+	return $proc->next_tag( 'ul' ) === true || $proc->next_tag( 'ol' ) === true ? $content : '';
+}
+
+/**
+ * Provide the 'query' as context to a rendered block.
+ *
+ * @param array         $context      Default context.
+ * @param array         $parsed_block Block being rendered, filtered by `render_block_data`.
+ * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+ */
+function wp_curate_query_block_context( $context, $parsed_block, $parent_block ) {
+	if (
+		! isset( $parsed_block['blockName'], $parsed_block['attrs'] )
+		|| 'wp-curate/query' !== $parsed_block['blockName']
+	) {
+		return $context;
+	}
+
+	$attributes = $parsed_block['attrs'];
+
+	if ( isset( $attributes['name'] ) ) {
+		if ( 'profile-archive' === $attributes['name'] ) {
+			$profile = Profile::get_by_post( get_the_ID() );
+			if ( $profile instanceof Profile ) {
+				$context['query'] = [
+					'postType'  => 'post',
+					'taxQuery'  => [
+						'byline' => [ $profile->byline_id ],
+					],
+					'foundRows' => true,
+					'perPage'   => 15,
+				];
+			}
+		}
+	}
+
+	return $context;
+}
+add_filter( 'render_block_context', 'wp_curate_query_block_context', 10, 3 );

--- a/blocks/query/index.scss
+++ b/blocks/query/index.scss
@@ -1,0 +1,7 @@
+/**
+ * Editor styles for the wp-curate/query block.
+ */
+
+.wp-block-wp-curate-query {
+  border: 1px dotted #f00;
+}

--- a/blocks/query/index.ts
+++ b/blocks/query/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/blocks/query/style.scss
+++ b/blocks/query/style.scss
@@ -1,0 +1,10 @@
+/**
+ * Styles for the wp-curate/query block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-wp-curate-query {
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "alleyinteractive/composer-wordpress-autoloader": "^1.0"
+        "alleyinteractive/composer-wordpress-autoloader": "^1.0",
+        "alleyinteractive/laminas-validator-extensions": "^2.0",
+        "alleyinteractive/wp-match-blocks": "^3.0"
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",

--- a/src/class-block.php
+++ b/src/class-block.php
@@ -5,7 +5,7 @@
  * @package wp-curate
  */
 
-namespace WP_Curate\Core;
+namespace Alley\WP\WP_Curate;
 
 /**
  * A single block.

--- a/src/class-block.php
+++ b/src/class-block.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Block class file
+ *
+ * @package wp-curate
+ */
+
+namespace WP_Curate\Core;
+
+/**
+ * A single block.
+ */
+final class Block implements Serialized_Blocks {
+	/**
+	 * Set up.
+	 *
+	 * @param string               $block_name Block name.
+	 * @param array<string, mixed> $attrs      Block attributes.
+	 * @param string               $inner_html Block inner HTML.
+	 */
+	private function __construct(
+		private readonly string $block_name,
+		private readonly array $attrs,
+		private readonly string $inner_html,
+	) {}
+
+	/**
+	 * Create instance from a name or more.
+	 *
+	 * @param string               $name                Block name.
+	 * @param array<string, mixed> $attrs Block attributes.
+	 * @param string               $html                Block inner HTML.
+	 * @return self
+	 */
+	public static function create( string $name, array $attrs = [], string $html = '' ): self {
+		return new self( $name, $attrs, $html );
+	}
+
+	/**
+	 * Parsed block instance.
+	 *
+	 * @return array{
+	 *   blockName: string,
+	 *   attrs: array<string, mixed>,
+	 *   innerBlocks?: mixed[],
+	 *   innerHTML?: string,
+	 *   innerContent?: string[],
+	 * }
+	 */
+	public function parsed_block(): array {
+		return [
+			'blockName'    => $this->block_name,
+			'attrs'        => $this->attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => $this->inner_html,
+			'innerContent' => [ $this->inner_html ],
+		];
+	}
+
+	/**
+	 * Serialized block content.
+	 *
+	 * @return string
+	 */
+	public function serialize(): string {
+		return serialize_block( $this->parsed_block() );
+	}
+}

--- a/src/class-wp-utils.php
+++ b/src/class-wp-utils.php
@@ -5,7 +5,7 @@
  * @package wp-curate
  */
 
-namespace WP_Curate\Core;
+namespace Alley\WP\WP_Curate;
 
 /**
  * WordPress-specific helpers.

--- a/src/class-wp-utils.php
+++ b/src/class-wp-utils.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Class file for WP_Utils.
+ *
+ * @package wp-curate
+ */
+
+namespace WP_Curate\Core;
+
+/**
+ * WordPress-specific helpers.
+ */
+class WP_Utils {
+	/**
+	 * Whether we're DOING_AUTOSAVE.
+	 *
+	 * @return bool
+	 */
+	public static function doing_autosave() {
+		return ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE );
+	}
+
+	/**
+	 * Whether something is a \WP_Post.
+	 *
+	 * @param mixed $thing Thing to check.
+	 * @return bool
+	 */
+	public static function is_wp_post( $thing ) {
+		return ( $thing instanceof \WP_Post );
+	}
+
+	/**
+	 * Whether something is a \WP_Query.
+	 *
+	 * @param mixed $thing Thing to check.
+	 * @return bool
+	 */
+	public static function is_wp_query( $thing ) {
+		return ( $thing instanceof \WP_Query );
+	}
+
+	/**
+	 * Whether something is a \WP_Term.
+	 *
+	 * @param mixed $thing Thing to check.
+	 * @return bool
+	 */
+	public static function is_wp_term( $thing ) {
+		return ( $thing instanceof \WP_Term );
+	}
+
+	/**
+	 * Whether something is a \WP_User.
+	 *
+	 * @param mixed $thing Thing to check.
+	 * @return bool
+	 */
+	public static function is_wp_user( $thing ) {
+		return ( $thing instanceof \WP_User );
+	}
+
+	/**
+	 * Sanitize a 'posts_per_page' value to help avoid nonperformant queries.
+	 *
+	 * @param int $value The value to sanitize.
+	 * @return int Value between 1 and 100.
+	 */
+	public static function sanitize_posts_per_page( $value ) {
+		return max( 1, min( 100, intval( $value ) ) );
+	}
+
+	/**
+	 * Whether this is a WP_CLI session.
+	 *
+	 * @return bool
+	 */
+	public static function wp_cli() {
+		return ( defined( 'WP_CLI' ) && WP_CLI );
+	}
+
+	/**
+	 * Get the currently global $wp_query.
+	 *
+	 * @return mixed A query, in theory.
+	 */
+	public static function wp_query() {
+		global $wp_query;
+		return $wp_query;
+	}
+
+	/**
+	 * Get the currently global $wp_the_query.
+	 *
+	 * @return mixed *The* query, in theory.
+	 */
+	public static function wp_the_query() {
+		global $wp_the_query;
+		return $wp_the_query;
+	}
+
+	/**
+	 * Helper function to cache the return value of a function.
+	 *
+	 * @param string   $key Cache key.
+	 * @param \Closure $callback Closure to invoke.
+	 * @param string   $group Cache group.
+	 * @param int      $ttl Cache TTL.
+	 * @return mixed
+	 */
+	public static function remember( string $key, \Closure $callback, string $group = '', int $ttl = 3600 ) {
+		$found = false;
+		$value = wp_cache_get( $key, $group, false, $found );
+
+		if ( $found ) {
+			return $value;
+		}
+
+		$value = $callback();
+
+		wp_cache_set( $key, $value, $group, $ttl ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+
+		return $value;
+	}
+}

--- a/src/interface-serialized-blocks.php
+++ b/src/interface-serialized-blocks.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Serialized_Blocks interface file
+ *
+ * @package wp-curate
+ */
+
+namespace WP_Curate\Core;
+
+/**
+ * Describes a class that serializes block content.
+ */
+interface Serialized_Blocks {
+	/**
+	 * Serialized block content.
+	 *
+	 * @return string
+	 */
+	public function serialize(): string;
+}

--- a/src/interface-serialized-blocks.php
+++ b/src/interface-serialized-blocks.php
@@ -5,7 +5,7 @@
  * @package wp-curate
  */
 
-namespace WP_Curate\Core;
+namespace Alley\WP\WP_Curate;
 
 /**
  * Describes a class that serializes block content.


### PR DESCRIPTION
## Summary

Curation: Add existing blocks to plugin ([STORY-874](https://alleyinteractive.atlassian.net/browse/STORY-874))

This PR brings in some existing curation blocks and dependencies, updates the namespace and text domain to wp-curate, and then updates everything so that phpcs and phpstan checks pass.

## Notes for reviewers

None.

## Changelog entries

### Added

- Bring in existing blocks, change namespace and text domain

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Ticket(s)

- [STORY-874](https://alleyinteractive.atlassian.net/browse/STORY-874)


[STORY-874]: https://alleyinteractive.atlassian.net/browse/STORY-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STORY-874]: https://alleyinteractive.atlassian.net/browse/STORY-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ