### PR TITLE
block controls UI cleanup

### DIFF
--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -276,82 +277,75 @@ export default function Edit({
           initialOpen
         >
           {minNumberOfPosts !== undefined && minNumberOfPosts !== maxNumberOfPosts ? (
-            // @ts-ignore
-            <PanelRow>
+            <>
               { /* @ts-ignore */ }
               <RangeControl
                 label={__('Number of Posts', 'wp-curate')}
+                help={__('The maximun number of posts to show.', 'wp-curate')}
                 value={numberOfPosts}
                 onChange={(value) => setAttributes({ numberOfPosts: value })}
                 min={minNumberOfPosts}
                 max={maxNumberOfPosts}
               />
-            </PanelRow>
+            </>
           ) : null}
           { /* @ts-ignore */ }
-          <PanelRow>
-            { /* @ts-ignore */}
-            <RangeControl
-              label={__('Offset', 'wp-curate')}
-              onChange={(newValue) => setAttributes({ offset: newValue })}
-              value={offset}
-              min={0}
-              max={20}
-            />
-          </PanelRow>
-          { /* @ts-ignore */ }
-          <PanelRow
-            className="wp-curate-post-type-selector"
-          >
-            { /* @ts-ignore */ }
-            <SelectControl
-              label={__('Post Types', 'wp-curate')}
-              value={postTypes}
-              onChange={(newValue) => setAttributes({ postTypes: newValue })}
-              options={displayTypes}
-              multiple
-            />
-          </PanelRow>
-          { /* @ts-ignore */ }
+          <RangeControl
+            label={__('Offset', 'wp-curate')}
+            help={__('The number of post to pass over.', 'wp-curate')}
+            onChange={(newValue) => setAttributes({ offset: newValue })}
+            value={offset}
+            min={0}
+            max={20}
+          />
+          <SelectControl
+            label={__('Post Types', 'wp-curate')}
+            value={postTypes}
+            onChange={(newValue) => setAttributes({ postTypes: newValue })}
+            options={displayTypes}
+            multiple
+          />
           {Object.keys(availableTaxonomies).length > 0 ? (
             allowedTaxonomies.map((taxonomy) => (
               <>
                 { /* @ts-ignore */ }
-                <PanelRow>
-                  { /* @ts-ignore */ }
-                  <TermSelector
-                    label={availableTaxonomies[taxonomy].name}
-                    subTypes={[taxonomy]}
-                    selected={terms[taxonomy] ?? []}
-                    onSelect={(newCategories: Term[]) => setTerms(taxonomy, newCategories)}
-                  />
-                </PanelRow>
+                <TermSelector
+                  label={availableTaxonomies[taxonomy].name}
+                  subTypes={[taxonomy]}
+                  selected={terms[taxonomy] ?? []}
+                  onSelect={(newCategories: Term[]) => setTerms(taxonomy, newCategories)}
+                  multiple
+                />
               </>
             ))
           ) : null}
           { /* @ts-ignore */ }
-          <PanelRow>
-            { /* @ts-ignore */ }
-            <TextControl
-              label={__('Search Term', 'wp-curate')}
-              onChange={(next) => setAttributes({ searchTerm: next })}
-              value={searchTerm as string}
-            />
-          </PanelRow>
+          <TextControl
+            label={__('Search Term', 'wp-curate')}
+            onChange={(next) => setAttributes({ searchTerm: next })}
+            value={searchTerm as string}
+          />
         </PanelBody>
         { /* @ts-ignore */ }
         <PanelBody
           title={__('Manually Set Posts', 'wp-curate')}
           initialOpen
+          className="manual-posts"
         >
           {manualPosts.map((post, index) => (
             /* @ts-ignore */
-            <PanelRow>
+            <PanelRow className={classnames(
+              'manual-posts__container',
+              { 'manual-posts__container--selected': manualPosts[index] },
+            )}
+            >
+              <span className="manual-posts__counter">{index + 1}</span>
               <PostPicker
                 allowedTypes={allowedPostTypes}
                 onReset={() => setManualPost(0, index)}
                 onUpdate={(id: number) => { setManualPost(id, index); }}
                 value={manualPosts[index] ?? 0}
+                className="manual-posts__picker"
               />
             </PanelRow>
           ))}

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -281,7 +281,7 @@ export default function Edit({
               { /* @ts-ignore */ }
               <RangeControl
                 label={__('Number of Posts', 'wp-curate')}
-                help={__('The maximun number of posts to show.', 'wp-curate')}
+                help={__('The maximum number of posts to show.', 'wp-curate')}
                 value={numberOfPosts}
                 onChange={(value) => setAttributes({ numberOfPosts: value })}
                 min={minNumberOfPosts}
@@ -292,7 +292,7 @@ export default function Edit({
           { /* @ts-ignore */ }
           <RangeControl
             label={__('Offset', 'wp-curate')}
-            help={__('The number of post to pass over.', 'wp-curate')}
+            help={__('The number of posts to pass over.', 'wp-curate')}
             onChange={(newValue) => setAttributes({ offset: newValue })}
             value={offset}
             min={0}

--- a/blocks/query/index.scss
+++ b/blocks/query/index.scss
@@ -2,6 +2,44 @@
  * Editor styles for the wp-curate/query block.
  */
 
-.wp-curate-post-type-selector .components-base-control {
-  width: 100%;
+.autocomplete__component .components-base-control__label {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-transform: uppercase;
+  display: inline-block;
+  margin-bottom: 8px;
+}
+
+.manual-posts__container {
+  gap: 1rem;
+}
+
+.manual-posts__picker {
+  border: 1px dashed #e0e0e0;
+  flex: 1;
+  padding: 8px;
+
+  > .components-button {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .manual-posts__container--selected & {
+    border: 0 none;
+    padding: 0 0 16px;
+
+    > * {
+      width: 100%;
+    }
+  }
+}
+
+.manual-posts__counter {
+  font-weight: 500;
+  
+  // Give counters a min-width if there are double digits.
+  .manual-posts:has(.manual-posts__container:nth-last-child(10)) & {
+    min-width: 18px;
+  }
 }

--- a/blocks/query/index.scss
+++ b/blocks/query/index.scss
@@ -3,12 +3,12 @@
  */
 
 .autocomplete__component .components-base-control__label {
+  display: inline-block;
   font-size: 11px;
   font-weight: 500;
   line-height: 1.4;
-  text-transform: uppercase;
-  display: inline-block;
   margin-bottom: 8px;
+  text-transform: uppercase;
 }
 
 .manual-posts__container {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@wordpress/warning": "^2.30.0",
         "@wordpress/widgets": "^3.7.0",
         "@wordpress/wordcount": "^3.30.0",
+        "classnames": "^2.3.2",
         "dompurify": "^3.0.5",
         "prop-types": "^15.8.1",
         "react": "18.2.0",
@@ -8295,7 +8296,8 @@
     },
     "node_modules/classnames": {
       "version": "2.3.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-webpack-plugin": {
       "version": "4.0.0",
@@ -24642,7 +24644,9 @@
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "classnames": {
-      "version": "2.3.2"
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-webpack-plugin": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@wordpress/warning": "^2.30.0",
     "@wordpress/widgets": "^3.7.0",
     "@wordpress/wordcount": "^3.30.0",
+    "classnames": "^2.3.2",
     "dompurify": "^3.0.5",
     "prop-types": "^15.8.1",
     "react": "18.2.0",


### PR DESCRIPTION
Cleans up the block controls and styles the manual posts selector panel.
Note: [hiding whitespace](https://github.com/alleyinteractive/wp-curate/pull/29/files?diff=unified&w=1) will be helpful when reviewing.