### PR TITLE
Issue-73: In Query block add AND/OR option for multiple terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
-## 0.1.0 - 202X-XX-XX
+## 1.2.0 - 2023-10-26
+
+- Adds support for AND/OR operators in the Query Parameters, giving more control over what posts to show.
+
+## 1.1.0 - 2023-09-21
+
+- Bug fix: prevents error if post type does not support meta.
+
+## 1.0.0 - 2023-09-19
 
 - Initial release

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -74,6 +74,26 @@
         "type": "array"
       },
       "type": "object"
+    },
+    "termRelations": {
+      "default": {},
+      "items": {
+        "default": "AND",
+        "enum": [
+          "AND",
+          "OR"
+        ],
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "taxRelation": {
+      "default": "AND",
+      "enum": [
+        "AND",
+        "OR"
+      ],
+      "type": "string"
     }
   }
 }

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -345,7 +345,7 @@ export default function Edit({
                   <SelectControl
                     label={sprintf(
                       __('%s Relation', 'wp-curate'),
-                      availableTaxonomies[taxonomy].name || taxonomy
+                      availableTaxonomies[taxonomy].name || taxonomy,
                     )}
                     help={__('AND: Posts must have all selected terms. OR: Posts may have one or more selected terms.', 'wp-curate')}
                     options={[

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -109,10 +109,7 @@ export default function Edit({
   const [availableTaxonomies, setAvailableTaxonomies] = useState<Taxonomies>({});
   const [availableTypes, setAvailableTypes] = useState<Types>({});
 
-  const taxCount = allowedTaxonomies.reduce((acc: number, taxonomy: string) => {
-    const hasTax = terms[taxonomy]?.length > 0 ? 1 : 0;
-    return acc + hasTax;
-  }, 0);
+  const taxCount = allowedTaxonomies.filter((taxonomy: string) => terms[taxonomy]?.length > 0).length; // eslint-disable-line max-len
 
   const termQueryArgs = buildTermQueryArgs(
     allowedTaxonomies,

--- a/blocks/query/types.ts
+++ b/blocks/query/types.ts
@@ -15,6 +15,10 @@ interface EditProps {
     terms?: {
       [key: string]: any[];
     };
+    termRelations?: {
+      [key: string]: string;
+    };
+    taxRelation?: string;
   };
   setAttributes: (attributes: any) => void;
 }

--- a/services/buildTermQueryArgs/index.ts
+++ b/services/buildTermQueryArgs/index.ts
@@ -8,17 +8,15 @@
  * @param string taxRelation The AND/OR relation used for all the terms.
  * @returns string The term query args.
  */
-export default function buildTermQueryArts(
+export default function buildTermQueryArgs(
   allowedTaxonomies: string[],
   terms: { [key: string]: any[] },
   availableTaxonomies: { [key: string]: any },
   termRelations: { [key: string]: string },
   taxRelation: string,
 ): string {
-  const taxCount = allowedTaxonomies.reduce((acc: number, taxonomy: string) => {
-    const hasTax = terms[taxonomy]?.length > 0 ? 1 : 0;
-    return acc + hasTax;
-  }, 0);
+  const taxCount = allowedTaxonomies.filter((taxonomy: string) => terms[taxonomy]?.length > 0).length; // eslint-disable-line max-len
+
   const termQueryArgs: string[] = [];
   if (Object.keys(availableTaxonomies).length > 0) {
     allowedTaxonomies.forEach((taxonomy) => {

--- a/services/buildTermQueryArgs/index.ts
+++ b/services/buildTermQueryArgs/index.ts
@@ -1,3 +1,11 @@
+interface Types {
+  [key: string]: {
+    name: string;
+    slug: string;
+    rest_base: string;
+  };
+}
+
 /**
  * Builds the term query args for the WP REST API.
  *
@@ -11,7 +19,7 @@
 export default function buildTermQueryArgs(
   allowedTaxonomies: string[],
   terms: { [key: string]: any[] },
-  availableTaxonomies: { [key: string]: any },
+  availableTaxonomies: Types,
   termRelations: { [key: string]: string },
   taxRelation: string,
 ): string {

--- a/services/buildTermQueryArgs/index.ts
+++ b/services/buildTermQueryArgs/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Builds the term query args for the WP REST API.
+ *
+ * @param string[] allowedTaxonomies The list of allowed taxonomies.
+ * @param { [key: string]: any[] } terms The selected terms.
+ * @param { [key: string]: any[] } availableTaxonomies The available taxonomies.
+ * @param { [key: string]: string } termRelations The AND/OR relation used for each taxonomy.
+ * @param string taxRelation The AND/OR relation used for all the terms.
+ * @returns string The term query args.
+ */
+export default function buildTermQueryArts(
+  allowedTaxonomies: string[],
+  terms: { [key: string]: any[] },
+  availableTaxonomies: { [key: string]: any },
+  termRelations: { [key: string]: string },
+  taxRelation: string,
+): string {
+  const taxCount = allowedTaxonomies.reduce((acc: number, taxonomy: string) => {
+    const hasTax = terms[taxonomy]?.length > 0 ? 1 : 0;
+    return acc + hasTax;
+  }, 0);
+  const termQueryArgs: string[] = [];
+  if (Object.keys(availableTaxonomies).length > 0) {
+    allowedTaxonomies.forEach((taxonomy) => {
+      if (terms[taxonomy]?.length > 0) {
+        const restBase = availableTaxonomies[taxonomy].rest_base;
+        if (restBase) {
+          termQueryArgs.push(`${restBase}[terms]=${terms[taxonomy].map((term) => term.id).join(',')}`);
+          if (termRelations[taxonomy] !== '' && typeof termRelations[taxonomy] !== 'undefined') {
+            termQueryArgs.push(`${restBase}[operator]=${termRelations[taxonomy]}`);
+          }
+        }
+      }
+    });
+    if (taxCount > 1) {
+      termQueryArgs.push(`tax_relation=${taxRelation}`);
+    }
+  }
+  return termQueryArgs.join('&');
+}

--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -121,13 +121,13 @@ export function mainDedupe() {
   queryBlocks.forEach((queryBlock) => {
     const { attributes } = queryBlock;
     const {
-      backfillPosts = [],
+      backfillPosts = null,
       deduplication = 'inherit',
       posts = [],
       numberOfPosts = 5,
       postTypes = ['post'],
     } = attributes;
-    if (!backfillPosts.length) {
+    if (!backfillPosts) {
       return;
     }
     const postTypeString = postTypes.join(',');

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -51,7 +51,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 
 		if ( isset( $attributes['terms'] ) && is_array( $attributes['terms'] ) && count( $attributes['terms'] ) > 0 ) {
 			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				'relation' => 'AND',
+				'relation' => $attributes['taxRelation'] ?? 'AND',
 			];
 
 			foreach ( $attributes['terms'] as $taxonomy => $terms ) {
@@ -59,6 +59,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 					$args['tax_query'][] = [
 						'taxonomy' => $taxonomy,
 						'terms'    => array_column( $terms, 'id' ),
+						'operator' => $attributes['termsRelation'][ $taxonomy ] ?? 'AND',
 					];
 				}
 			}

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -59,7 +59,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 					$args['tax_query'][] = [
 						'taxonomy' => $taxonomy,
 						'terms'    => array_column( $terms, 'id' ),
-						'operator' => $attributes['termsRelation'][ $taxonomy ] ?? 'AND',
+						'operator' => is_array( $attributes['termRelations'] ) ? $attributes['termRelations'][ $taxonomy ] ?? 'AND' : 'AND',
 					];
 				}
 			}

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.3


### PR DESCRIPTION

## Description

This PR addresses issue #73: "In Query block add AND/OR option for multiple terms."

### Changes

- Allow users to select if the tax_query is AND or OR when multiple terms are selected
- Update the admin and front end to reflect the new functionality

### How to Test

1. Create a new Query block
2. Add multiple terms to the block
3. Use the new drop-down to choose between AND or OR for the tax query behavior

Fixes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Enhanced the WP Curate plugin to version 1.2.0, introducing more control over post display with AND/OR operators in Query Parameters. This allows users to fine-tune their content curation based on specific taxonomies and term relations.
- Refactor: Simplified the codebase by introducing a new function `buildTermQueryArgs` that efficiently constructs term query arguments for the WP REST API.
- Bug Fix: Addressed an issue in version 1.1.0 that caused an error when the post type did not support meta. This ensures a smoother user experience across different post types.
- Documentation: Updated the CHANGELOG.md to reflect the new features and bug fixes in the recent versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->