### PR TITLE
Better support for the default `post` behavior

### DIFF
--- a/blocks/query/index.php
+++ b/blocks/query/index.php
@@ -16,6 +16,7 @@ use Alley\WP\WP_Curate\Supported_Post_Types;
  */
 function wp_curate_query_block_init(): void {
 	$supported_post_types = new Supported_Post_Types();
+
 	if ( ! in_array( $supported_post_types->get_current_post_type(), $supported_post_types->get_supported_post_types(), true ) ) {
 		return;
 	}

--- a/entries/slotfills/index.php
+++ b/entries/slotfills/index.php
@@ -9,36 +9,35 @@
 
 namespace Alley\WP\WP_Curate;
 
-add_action(
-	'enqueue_block_editor_assets',
-	__NAMESPACE__ . '\action_enqueue_slotfills_assets'
-);
-
 /**
  * Registers all slotfill assets so that they can be enqueued through Gutenberg in
  * the corresponding context.
  */
 function register_slotfills_scripts(): void {
-	// Automatically load dependencies and version.
-	$asset_file = include __DIR__ . '/index.asset.php';
-
 	/**
 	 * Filter the post types that will show the "Enable Deduplication" slotfill.
+	 *
+	 * @param array $allowed_post_types The post types that will show the "Enable Deduplication" slotfill.
 	 */
 	$allowed_post_types = apply_filters( 'wp_curate_duduplication_slotfill_post_types', [ 'page', 'post' ] );
 
-	$post_type = get_editor_post_type();
-
-	if ( in_array( $post_type, $allowed_post_types, true ) ) {
-		wp_register_script(
-			'wp-curate_slotfills',
-			plugins_url( 'index.js', __FILE__ ),
-			$asset_file['dependencies'],
-			$asset_file['version'],
-			true
-		);
-		wp_set_script_translations( 'wp-curate_slotfills', 'wp-curate' );
+	$supported_post_types = new Supported_Post_Types();
+	if ( ! in_array( $supported_post_types->get_current_post_type(), $allowed_post_types, true ) ) {
+		return;
 	}
+
+	// Automatically load dependencies and version.
+	$asset_file = include __DIR__ . '/index.asset.php';
+
+	wp_register_script(
+		'wp-curate_slotfills',
+		plugins_url( 'index.js', __FILE__ ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
+		true
+	);
+
+	wp_set_script_translations( 'wp-curate_slotfills', 'wp-curate' );
 }
 add_action( 'init', __NAMESPACE__ . '\register_slotfills_scripts' );
 
@@ -48,30 +47,7 @@ add_action( 'init', __NAMESPACE__ . '\register_slotfills_scripts' );
 function action_enqueue_slotfills_assets(): void {
 	wp_enqueue_script( 'wp-curate_slotfills' );
 }
-
-/**
- * Gets the post type currently being edited.
- *
- * @return string|false
- */
-function get_editor_post_type() {
-	// Set the default post type.
-	$post_type = '';
-
-	// Ensure we are in the admin before proceeding.
-	if ( is_admin() ) {
-		global $pagenow;
-
-		// phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.NonceVerification.Recommended
-		if ( 'post.php' === $pagenow && ! empty( $_GET['post'] ) ) {
-			// phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.Recommended
-			$post_id   = absint( $_GET['post'] );
-			$post_type = get_post_type( $post_id );
-		// phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.NonceVerification.Recommended
-		} elseif ( 'post-new.php' === $pagenow && ! empty( $_GET['post_type'] ) ) {
-			// phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.Recommended
-			$post_type = sanitize_text_field( $_GET['post_type'] );
-		}
-	}
-	return $post_type;
-}
+add_action(
+	'enqueue_block_editor_assets',
+	__NAMESPACE__ . '\action_enqueue_slotfills_assets'
+);

--- a/src/class-supported-post-types.php
+++ b/src/class-supported-post-types.php
@@ -42,6 +42,11 @@ final class Supported_Post_Types {
 	 * @return string[]
 	 */
 	public function get_supported_post_types(): array {
+		/**
+		 * Filter the WP Curate supported post types.
+		 *
+		 * @param string[] $supported_post_types The supported post types.
+		 */
 		return apply_filters( 'wp_curate_supported_post_types', $this->supported_post_types );
 	}
 
@@ -63,9 +68,13 @@ final class Supported_Post_Types {
 				$post_id   = absint( $_GET['post'] );
 				$post_type = get_post_type( $post_id );
 			// phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.NonceVerification.Recommended
-			} elseif ( 'post-new.php' === $pagenow && ! empty( $_GET['post_type'] ) ) {
-				// phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.Security.NonceVerification.Recommended
-				$post_type = sanitize_text_field( $_GET['post_type'] );
+			} elseif ( 'post-new.php' === $pagenow ) {
+				if ( ! empty( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					$post_type = sanitize_text_field( $_GET['post_type'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				} else {
+					// Default to post.
+					$post_type = 'post';
+				}
 			}
 		}
 		return $post_type;


### PR DESCRIPTION
## Summary

Changes to better support the default `post` behavior.

### How to Test
- Create a new `post` post: https://wp.test/wp-admin/post-new.php
- Confirm the Query block is available for selection;
- Confirm the "Deduplication" slotfill is available for selection;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Enhanced the software's intuitiveness by adding a new feature that checks if the current post type is supported. This prevents users from making changes to unsupported post types, improving the user experience.
- Added a filter in the `initialize_supported_post_types` function, allowing users to customize the supported post types. This provides more flexibility and control to the users.

Refactor:
- Simplified the code by removing the `get_editor_post_type` function and moving certain function calls inside a conditional statement. This makes the code cleaner and easier to maintain.
- Improved the handling of new posts by defaulting to the 'post' post type if no specific post type is provided. This makes the software more user-friendly, especially for new users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->