### PR TITLE
Truly return `string[]`

### DIFF
--- a/src/class-supported-post-types.php
+++ b/src/class-supported-post-types.php
@@ -32,7 +32,7 @@ final class Supported_Post_Types {
 		// Get all post types.
 		$post_types                 = get_post_types( [], 'objects' );
 		$supported_post_types       = array_filter( $post_types, fn( $type ) => $type->public && use_block_editor_for_post_type( $type->name ) );
-		$this->supported_post_types = ( wp_list_pluck( $supported_post_types, 'name' ) );
+		$this->supported_post_types = array_keys( wp_list_pluck( $supported_post_types, 'name' ) );
 		$this->register_post_meta();
 	}
 


### PR DESCRIPTION
This is what I would get before this change:

```
[27-Oct-2023 19:30:55 UTC] {"post":"post","page":"page","profile":"profile"}
[27-Oct-2023 19:30:55 UTC] {"post":"post","page":"page","profile":"profile"}
[27-Oct-2023 19:30:55 UTC] ["page","post"]
```

This is what I get now:

```
[27-Oct-2023 19:30:55 UTC] ["page","post"]
[27-Oct-2023 19:30:55 UTC] ["page","post"]
[27-Oct-2023 19:30:55 UTC] ["page","post"]
```

Oddly, this runs multiple times. I'll suggest in a different pr so that this is cached statically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Refactor: Updated the method for identifying supported post types in the system. This change ensures more accurate tracking of post types, but does not alter the overall functionality or user experience. Users will continue to interact with the system as usual, with the underlying processes now being more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->