### PR TITLE
fix supported post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.4.1 - 2023-11-01
+
+- Bug fix: allow blocks when no post type is defined.
+
 ## 1.4.0 - 2023-10-30
 
 - Bug fix: prevents error if `termRelations` attribute is not set.

--- a/blocks/post/index.php
+++ b/blocks/post/index.php
@@ -12,7 +12,7 @@ use Alley\WP\WP_Curate\Supported_Post_Types;
  */
 function wp_curate_post_block_init(): void {
 	$supported_post_types = new Supported_Post_Types();
-	if ( ! in_array( $supported_post_types->get_current_post_type(), $supported_post_types->get_supported_post_types(), true ) ) {
+	if ( ! $supported_post_types->should_register_block() ) {
 		return;
 	}
 

--- a/blocks/query/index.php
+++ b/blocks/query/index.php
@@ -17,7 +17,7 @@ use Alley\WP\WP_Curate\Supported_Post_Types;
 function wp_curate_query_block_init(): void {
 	$supported_post_types = new Supported_Post_Types();
 
-	if ( ! in_array( $supported_post_types->get_current_post_type(), $supported_post_types->get_supported_post_types(), true ) ) {
+	if ( ! $supported_post_types->should_register_block() ) {
 		return;
 	}
 

--- a/entries/slotfills/index.php
+++ b/entries/slotfills/index.php
@@ -22,7 +22,7 @@ function register_slotfills_scripts(): void {
 	$allowed_post_types = apply_filters( 'wp_curate_duduplication_slotfill_post_types', [ 'page', 'post' ] );
 
 	$supported_post_types = new Supported_Post_Types();
-	if ( ! in_array( $supported_post_types->get_current_post_type(), $allowed_post_types, true ) ) {
+	if ( ! $supported_post_types->should_register_block() ) {
 		return;
 	}
 

--- a/src/assets.php
+++ b/src/assets.php
@@ -31,15 +31,6 @@ function action_wp_enqueue_scripts(): void {
 	|     https://github.com/alleyinteractive/wp-asset-manager
 	|
 	*/
-
-	// wp_enqueue_script(
-	//  'wp-curate-example-entry',
-	//  get_entry_asset_url( 'example-entry' ),
-	//  get_asset_dependency_array( 'example-entry' ),
-	//  get_asset_version( 'example-entry' ),
-	//  true
-	// );
-	// wp_set_script_translations( 'wp-curate-example-entry', 'wp-curate' );
 }
 
 /**
@@ -55,15 +46,6 @@ function action_admin_enqueue_scripts(): void {
 	| assets that are loaded only in the WordPress admin.
 	|
 	*/
-
-	// wp_enqueue_script(
-	//  'wp-curate-admin-handle',
-	//  get_entry_asset_url( 'admin-handle' ),
-	//  get_asset_dependency_array( 'admin-handle' ),
-	//  get_asset_version( 'admin-handle' ),
-	//  true
-	// );
-	// wp_set_script_translations( 'wp-curate-admin-handle', 'wp-curate' );
 }
 
 /**
@@ -79,15 +61,6 @@ function action_enqueue_block_editor_assets(): void {
 	| enqueue assets that are loaded in the block editor.
 	|
 	*/
-
-	// wp_enqueue_script(
-	//  'wp-curate-slotfills',
-	//  get_entry_asset_url( 'slotfills' ),
-	//  get_asset_dependency_array( 'slotfills' ),
-	//  get_asset_version( 'slotfills' ),
-	//  true
-	// );
-	// wp_set_script_translations( 'wp-curate-slotfills', 'wp-curate' );
 }
 
 /**

--- a/src/class-supported-post-types.php
+++ b/src/class-supported-post-types.php
@@ -99,7 +99,7 @@ final class Supported_Post_Types {
 	 *
 	 * @return boolean
 	 */
-	public function should_register_block() {
+	public function should_register_block(): bool {
 		return empty( $this->get_current_post_type() ) || in_array( $this->get_current_post_type(), $this->get_supported_post_types(), true );
 	}
 }

--- a/src/class-supported-post-types.php
+++ b/src/class-supported-post-types.php
@@ -93,4 +93,13 @@ final class Supported_Post_Types {
 			]
 		);
 	}
+
+	/**
+	 * Should we register the block in the current context.
+	 *
+	 * @return boolean
+	 */
+	public function should_register_block() {
+		return empty( $this->get_current_post_type() ) || in_array( $this->get_current_post_type(), $this->get_supported_post_types(), true );
+	}
 }

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.3


### PR DESCRIPTION
allow block when no post type defined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Bug Fixes:
- Fixed an issue in version 1.4.1 of `WP Curate` where blocks were not being displayed when no post type was specified. Blocks can now be displayed even when no post type is defined, improving the user experience.

Chores:
- Updated the version of the WP Curate plugin from 1.4.0 to 1.4.1, ensuring users have the latest version with bug fixes and improvements.

Refactor:
- Refactored the code in `blocks/post/index.php` and `blocks/query/index.php` to improve the block registration process. The logic for determining whether to register the block has been moved to the `should_register_block()` method of the `Supported_Post_Types` class, making it more efficient and maintainable.

Documentation:
- No documentation changes were made in this release.

Style:
- No style changes were made in this release.

Tests:
- No new tests were added in this release.

Revert:
- No code reversions were made in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->