### PR TITLE
Feature/issue 73/add and or option multiple terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.4.2 - 2023-11-01
+
+- Bug fix: PHP tax_query wants `AND` or `IN` for `operator`. REST API wants `AND` or `OR`.
+
 ## 1.4.0 - 2023-10-30
 
 - Bug fix: prevents error if `termRelations` attribute is not set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `WP Curate` will be documented in this file.
 ## 1.4.2 - 2023-11-01
 
 - Bug fix: PHP tax_query wants `AND` or `IN` for `operator`. REST API wants `AND` or `OR`.
+- Default operator should be `OR`/`IN`.
 
 ## 1.4.1 - 2023-11-01
 

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -86,7 +86,7 @@ export default function Edit({
   ];
 
   // @ts-ignore
-  const [isPostDeduplicating, postTypeObject] = useSelect(
+  const [isPostDeduplicating, postTypeObject, postId] = useSelect(
     (select) => {
       // @ts-ignore
       const editor = select('core/editor');
@@ -95,12 +95,15 @@ export default function Edit({
       const type = editor.getEditedPostAttribute('type');
       // @ts-ignore
       const meta = editor.getEditedPostAttribute('meta');
+      // @ts-ignore
+      const id = editor.getEditedPostAttribute('id');
 
       return [
         // It's possible for usePostMetaValue() to run here before useEntityProp() is available.
         Boolean(meta?.wp_curate_deduplication),
         // @ts-ignore
         type ? select('core').getPostType(type) : null,
+        id,
       ];
     },
   );
@@ -154,7 +157,9 @@ export default function Edit({
           search: debouncedSearchTerm,
           offset,
           type: postTypeString,
+          status: 'publish',
           per_page: 20,
+          exclude: postId,
         },
       );
       path += `&${termQueryArgs}`;
@@ -176,6 +181,7 @@ export default function Edit({
     postTypeString,
     availableTaxonomies,
     setAttributes,
+    postId,
   ]);
 
   // Update the query when the backfillPosts change.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -91,7 +91,7 @@ export default function Edit({
   ];
 
   // @ts-ignore
-  const [isPostDeduplicating, postTypeObject, postId] = useSelect(
+  const [isPostDeduplicating, postTypeObject] = useSelect(
     (select) => {
       // @ts-ignore
       const editor = select('core/editor');
@@ -100,8 +100,6 @@ export default function Edit({
       const type = editor.getEditedPostAttribute('type');
       // @ts-ignore
       const meta = editor.getEditedPostAttribute('meta');
-      // @ts-ignore
-      const id = editor.getEditedPostAttribute('id');
 
       return [
         // It's possible for usePostMetaValue() to run here before useEntityProp() is available.
@@ -164,7 +162,6 @@ export default function Edit({
           type: postTypeString,
           status: 'publish',
           per_page: 20,
-          exclude: postId,
         },
       );
       path += `&${termQueryArgs}`;
@@ -186,7 +183,6 @@ export default function Edit({
     postTypeString,
     availableTaxonomies,
     setAttributes,
-    postId,
   ]);
 
   // Update the query when the backfillPosts change.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -106,7 +106,6 @@ export default function Edit({
         Boolean(meta?.wp_curate_deduplication),
         // @ts-ignore
         type ? select('core').getPostType(type) : null,
-        id,
       ];
     },
   );

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -72,7 +72,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		if ( is_string( $search_term ) && strlen( $search_term ) > 0 ) {
 			$args['s'] = $search_term;
 		}
-		$args['post__not_in'] = [ get_the_id() ]; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn
+		$args['post__not_in'] = [ get_the_id() ]; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
 

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -56,7 +56,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 
 			foreach ( $attributes['terms'] as $taxonomy => $terms ) {
 				if ( taxonomy_exists( $taxonomy ) && is_array( $terms ) && count( $terms ) > 0 ) {
-					$operator            = isset( $attributes['termRelations'] ) && is_array( $attributes['termRelations'] ) ? $attributes['termRelations'][ $taxonomy ] ?? 'AND' : 'OR';
+					$operator            = isset( $attributes['termRelations'] ) && is_array( $attributes['termRelations'] ) ? $attributes['termRelations'][ $taxonomy ] ?? 'OR' : 'OR';
 					$args['tax_query'][] = [
 						'taxonomy' => $taxonomy,
 						'terms'    => array_column( $terms, 'id' ),

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -72,7 +72,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		if ( is_string( $search_term ) && strlen( $search_term ) > 0 ) {
 			$args['s'] = $search_term;
 		}
-		$args[ 'post__not_in' ] = [ get_the_id() ];
+		$args['post__not_in'] = [ get_the_id() ]; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
 

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -56,10 +56,12 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 
 			foreach ( $attributes['terms'] as $taxonomy => $terms ) {
 				if ( taxonomy_exists( $taxonomy ) && is_array( $terms ) && count( $terms ) > 0 ) {
+					$operator            = isset( $attributes['termRelations'] ) && is_array( $attributes['termRelations'] ) ? $attributes['termRelations'][ $taxonomy ] ?? 'AND' : 'OR';
 					$args['tax_query'][] = [
 						'taxonomy' => $taxonomy,
 						'terms'    => array_column( $terms, 'id' ),
-						'operator' => is_array( $attributes['termRelations'] ) ? $attributes['termRelations'][ $taxonomy ] ?? 'AND' : 'AND',
+						// Note: Tax_query wants 'AND' or 'IN' for operator. The REST API wants 'AND' or 'OR'.
+						'operator' => 'OR' === $operator ? 'IN' : $operator,
 					];
 				}
 			}
@@ -70,6 +72,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		if ( is_string( $search_term ) && strlen( $search_term ) > 0 ) {
 			$args['s'] = $search_term;
 		}
+		$args[ 'post__not_in' ] = [ get_the_id() ];
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
 

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -72,7 +72,6 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		if ( is_string( $search_term ) && strlen( $search_term ) > 0 ) {
 			$args['s'] = $search_term;
 		}
-		$args['post__not_in'] = [ get_the_id() ]; // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
 

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.4.0
+ * Version: 1.4.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.3


### PR DESCRIPTION
Fixes issue in the PHP handling.

php tax_query wants `AND` or `IN`, but the REST API wants `AND` or `OR`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Bug Fixes:
- Fixed a bug in the `WP Curate` plugin (version 1.4.2) that ensures the `operator` value for `tax_query` aligns with the requirements of both PHP and the REST API. This change improves the accuracy of post queries.
- Updated the `useSelect` hook in `blocks/query/edit.tsx` to return `isPostDeduplicating`, `postTypeObject`, and `postId`. This change enhances the post editing experience by excluding the current post from the query results.
- The `WP Curate` plugin version has been updated from 1.4.0 to 1.4.2, reflecting the above changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->