### PR TITLE
Feature: Hide Deduplicate Slot Fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.4.3 - 2023-11-28
+
+- Bug fix: Adds in a temporary fix for https://github.com/alleyinteractive/alley-scripts/issues/473
+- Bug fix: Lock [nunomaduro/collision](https://github.com/nunomaduro/collision) at v6.0. Fixes failing tests via Github Actions.
+
 ## 1.4.2 - 2023-11-01
 
 - Bug fix: PHP tax_query wants `AND` or `IN` for `operator`. REST API wants `AND` or `OR`.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "php": "^8.1",
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/traverse-reshape": "^2.0",
-    "alleyinteractive/wp-type-extensions": "dev-main"
+    "alleyinteractive/wp-type-extensions": "dev-main",
+    "nunomaduro/collision": "^6.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",

--- a/entries/slotfills/deduplication/deduplication.tsx
+++ b/entries/slotfills/deduplication/deduplication.tsx
@@ -3,6 +3,18 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { usePostMetaValue } from '@alleyinteractive/block-editor-tools';
 
+/**
+ * The following code is a temporary fix.
+ *
+ * Once the issue linked below is taken care of, this code can be removed.
+ * @link https://github.com/alleyinteractive/alley-scripts/issues/473
+ */
+// @ts-ignore This is a temporary assignment.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { cloneDeep } from 'lodash';
+// @ts-ignore This is a temporary assignment.
+window.cloneDeepTemp = cloneDeep;
+
 function Deduplication() {
   const [deduplication, setDeduplication] = usePostMetaValue('wp_curate_deduplication');
 

--- a/entries/slotfills/deduplication/deduplication.tsx
+++ b/entries/slotfills/deduplication/deduplication.tsx
@@ -12,11 +12,20 @@ import { usePostMetaValue } from '@alleyinteractive/block-editor-tools';
 // @ts-ignore This is a temporary assignment.
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { cloneDeep } from 'lodash';
+import { useSelect } from '@wordpress/data';
+import countBlocksByName from '@/services/countBlocksByName';
 // @ts-ignore This is a temporary assignment.
 window.cloneDeepTemp = cloneDeep;
 
 function Deduplication() {
   const [deduplication, setDeduplication] = usePostMetaValue('wp_curate_deduplication');
+  // @ts-ignore - useSelect doesn't export proper types
+  const blocks = useSelect((select) => select('core/block-editor').getBlocks(), []);
+  const queryBlocksFound = countBlocksByName(blocks, 'wp-curate/query');
+
+  if (queryBlocksFound < 2) {
+    return null;
+  }
 
   return (
     <PluginDocumentSettingPanel

--- a/entries/slotfills/deduplication/deduplication.tsx
+++ b/entries/slotfills/deduplication/deduplication.tsx
@@ -6,7 +6,7 @@ import { usePostMetaValue } from '@alleyinteractive/block-editor-tools';
 /**
  * The following code is a temporary fix.
  *
- * Once the issue linked below is taken care of, this code can be removed.
+ * Once the issue linked below is resolved, this code can be removed.
  * @link https://github.com/alleyinteractive/alley-scripts/issues/473
  */
 // @ts-ignore This is a temporary assignment.

--- a/services/countBlocksByName/blocksStub.ts
+++ b/services/countBlocksByName/blocksStub.ts
@@ -1,0 +1,93 @@
+// eslint-disable-next-line import/prefer-default-export
+export const blocksWithColumns = [
+  {
+    clientId: '98c6ea3e-58fe-4f5b-b881-9a7ab2efc808',
+    name: 'core/heading',
+    innerBlocks: [],
+  },
+  {
+    clientId: '80828f03-6611-4303-8d31-9cfc78a8ef5b',
+    name: 'wp-curate/query',
+    innerBlocks: [],
+  },
+  {
+    clientId: 'e390aca0-c655-460b-ac01-49b7585ad0b3',
+    name: 'core/columns',
+    innerBlocks: [
+      {
+        clientId: '0af1fbf8-dfb3-4114-873b-85918473e3bd',
+        name: 'core/column',
+        innerBlocks: [
+          {
+            clientId: 'd99fb4c3-e941-471b-9687-3ca114667ce0',
+            name: 'core/heading',
+            innerBlocks: [],
+          },
+        ],
+      },
+      {
+        clientId: '692cfd82-cb31-4cd1-8d20-46ef2f02c246',
+        name: 'core/column',
+        innerBlocks: [
+          {
+            clientId: 'f54f92fb-b299-4069-ace7-141656b827b7',
+            name: 'wp-curate/query',
+            innerBlocks: [
+              {
+                clientId: 'd2092cce-30ea-41a4-84ed-7fac3168ce24',
+                name: 'core/heading',
+                innerBlocks: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    clientId: '4cd14787-9326-47de-b8e1-9b07ff084690',
+    name: 'wp-curate/query',
+    innerBlocks: [],
+  },
+];
+
+export const blocksWithNoQueryBlocks = [
+  {
+    clientId: '98c6ea3e-58fe-4f5b-b881-9a7ab2efc808',
+    name: 'core/heading',
+    innerBlocks: [],
+  },
+  {
+    clientId: 'e390aca0-c655-460b-ac01-49b7585ad0b3',
+    name: 'core/columns',
+    innerBlocks: [
+      {
+        clientId: '0af1fbf8-dfb3-4114-873b-85918473e3bd',
+        name: 'core/column',
+        innerBlocks: [
+          {
+            clientId: 'd99fb4c3-e941-471b-9687-3ca114667ce0',
+            name: 'core/heading',
+            innerBlocks: [],
+          },
+        ],
+      },
+      {
+        clientId: '692cfd82-cb31-4cd1-8d20-46ef2f02c246',
+        name: 'core/column',
+        innerBlocks: [
+          {
+            clientId: 'f54f92fb-b299-4069-ace7-141656b827b7',
+            name: 'core/heading',
+            innerBlocks: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    clientId: '4cd14787-9326-47de-b8e1-9b07ff084690',
+    name: 'core/heading',
+    innerBlocks: [],
+  },
+];

--- a/services/countBlocksByName/index.test.ts
+++ b/services/countBlocksByName/index.test.ts
@@ -1,0 +1,14 @@
+import { blocksWithColumns, blocksWithNoQueryBlocks } from './blocksStub';
+import countBlocksByName from './index';
+
+describe('countBlocksByName', () => {
+  it('should return 3 when there are 3 query blocks', () => {
+    const count = countBlocksByName(blocksWithColumns, 'wp-curate/query');
+    expect(count).toBe(3);
+  });
+
+  it('it should return 0 when there are no query blcoks', () => {
+    const count = countBlocksByName(blocksWithNoQueryBlocks, 'wp-curate/query');
+    expect(count).toBe(0);
+  });
+});

--- a/services/countBlocksByName/index.test.ts
+++ b/services/countBlocksByName/index.test.ts
@@ -7,7 +7,7 @@ describe('countBlocksByName', () => {
     expect(count).toBe(3);
   });
 
-  it('it should return 0 when there are no query blcoks', () => {
+  it('should return 0 when there are no query blocks', () => {
     const count = countBlocksByName(blocksWithNoQueryBlocks, 'wp-curate/query');
     expect(count).toBe(0);
   });

--- a/services/countBlocksByName/index.ts
+++ b/services/countBlocksByName/index.ts
@@ -1,0 +1,28 @@
+interface Block {
+  clientId: string;
+  name: string;
+  innerBlocks: Block[];
+}
+
+/**
+ * Count blocks by name.
+ *
+ * @param blocks An array of blocks.
+ * @param blockName The name of the block to count.
+ * @param result The result of the count.
+ */
+export default function countBlocksByName(
+  blocks: Block[],
+  blockName: string,
+  result: Block[] | [{}] = [],
+): number {
+  for (const block of blocks) {
+    if (block.name === blockName) {
+      result.push(block);
+    }
+    if (block.innerBlocks && block.innerBlocks.length > 0) {
+      countBlocksByName(block.innerBlocks, blockName, result);
+    }
+  }
+  return result.length;
+}

--- a/services/countBlocksByName/index.ts
+++ b/services/countBlocksByName/index.ts
@@ -9,20 +9,21 @@ interface Block {
  *
  * @param blocks An array of blocks.
  * @param blockName The name of the block to count.
- * @param result The result of the count.
+ * @param count The current count.
  */
 export default function countBlocksByName(
   blocks: Block[],
   blockName: string,
-  result: Block[] | [{}] = [],
+  count = 0,
 ): number {
+  let newCount = count;
   for (const block of blocks) {
     if (block.name === blockName) {
-      result.push(block);
+      newCount += 1;
     }
     if (block.innerBlocks && block.innerBlocks.length > 0) {
-      countBlocksByName(block.innerBlocks, blockName, result);
+      newCount = countBlocksByName(block.innerBlocks, blockName, newCount);
     }
   }
-  return result.length;
+  return newCount;
 }

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.4.2
+ * Version: 1.4.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.3


### PR DESCRIPTION
Fixes #52 

Will hide the dedupe slot fill if there is only one query block on the page.

This PR contains a temporary workaround/fix for alleyinteractive/alley-scripts#473

GH Actions were failing for PHPUnit tests. After some help debugging, we realized that this repo is currently using PHPUnit 9 which uses nunomaduro/collision v7.0. In order to fix PHPUnit tests. we locked the collision package in at v6.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a block deduplication feature to improve content management.
  
- **Bug Fixes**
  - Implemented a temporary fix for block counting issues using a deep cloning method.

- **Tests**
  - Added test cases for the new `countBlocksByName` function to ensure accurate block counting.

- **Documentation**
  - Updated internal documentation to reflect changes in block structures and testing procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->