### PR TITLE
Fix the validate_file error on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.4.5 - 2023-12-12
+
+- Bug fix: Adds support to Windows file path validation with `validate_file` function.
+
 ## 1.4.4 - 2023-12-04
 
 - Bug fix: Update to the `Parsed_Block` new namespace.

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,8 +91,8 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "node": "18",
-        "npm": "9"
+        "node": ">=18",
+        "npm": ">= 9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "license": "GPL-2.0-or-later",
   "main": "wp-curate.php",
   "engines": {
-    "node": "18",
-    "npm": "9"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "browserslist": [
     "defaults",

--- a/src/assets.php
+++ b/src/assets.php
@@ -70,7 +70,7 @@ function action_enqueue_block_editor_assets(): void {
  * @return bool        True if the path is valid and the file exists.
  */
 function validate_path( string $path ): bool {
-	return 0 === validate_file( $path ) && file_exists( $path );
+	return ( 0 === validate_file( $path ) || 2 === validate_file( $path ) ) && file_exists( $path );
 }
 
 /**
@@ -173,7 +173,7 @@ function load_scripts(): void {
 
 	if ( ! empty( $files ) ) {
 		foreach ( $files as $path ) {
-			if ( 0 === validate_file( $path ) && file_exists( $path ) ) {
+			if ( validate_path( $path ) ) {
 				require_once $path;  // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.IncludingFile, WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 			}
 		}

--- a/src/meta.php
+++ b/src/meta.php
@@ -135,9 +135,7 @@ function register_meta_helper(
 function register_post_meta_from_defs(): void {
 	// Ensure the config file exists.
 	$filepath = dirname( __DIR__ ) . '/config/post-meta.json';
-	if ( ! file_exists( $filepath )
-		|| 0 !== validate_file( $filepath )
-	) {
+	if ( ! validate_path( $filepath ) ) {
 		return;
 	}
 

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.4.4
+ * Version: 1.4.5
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.3


### PR DESCRIPTION
## Summary
Fixes #109 to support Windows file paths by checking `validate_file` for both `0` and `2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved file validation process across the platform for enhanced security and stability.

- **Bug Fixes**
	- Streamlined the script loading mechanism to prevent issues related to file inclusion.
- **Documentation**
	- Updated CHANGELOG.md to reflect the bug fix and added support for Windows file path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->