### PR TITLE
Set PHP and node versions on built release task

### DIFF
--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -8,3 +8,6 @@ on:
 jobs:
   built-release:
     uses: alleyinteractive/.github/.github/workflows/built-release.yml@main
+    with:
+      node: 20
+      php: 8.2


### PR DESCRIPTION
Fixes a bug where the built-release task fails because it's using the default version of node for that task, which is 18, when this project requires 20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the build process to use the latest versions of Node.js and PHP for enhanced performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->