### PR TITLE
Move PostPicker below InnerBlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.5.1 - 2023-01-25
+
+- Bug Fix: Avoid BlockControl toolbar obstructing PostPicker button when Post inner blocks are selected.
+
 ## 1.5.0 - 2023-12-13
 
 - Enhancement: Bumps tested up to and requires WP to 6.4.

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -83,6 +83,7 @@ export default function Edit({
       },
     )}
     >
+      <InnerBlocks />
       {isParentOfSelectedBlock || isSelected ? (
         <PostPicker
           allowedTypes={postTypes}
@@ -96,7 +97,6 @@ export default function Edit({
           replaceText={__('Pin a different post', 'wp-curate')}
         />
       ) : null}
-      <InnerBlocks />
     </div>
   );
 }

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.5.0
+ * Version: 1.5.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
Avoid potential conflicts between BlockControl Toolbar and PostPicker button
See: https://github.com/alleyinteractive/wp-curate/issues/122