### PR TITLE
Rearrange Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     "php": "^8.1",
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/traverse-reshape": "^2.0",
-    "alleyinteractive/wp-type-extensions": "dev-main",
-    "nunomaduro/collision": "^6.0"
+    "alleyinteractive/wp-type-extensions": "^1.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",
     "mantle-framework/testkit": "^0.12",
+    "nunomaduro/collision": "^6.0",
     "szepeviktor/phpstan-wordpress": "^1.1"
   },
   "config": {


### PR DESCRIPTION
- Require a specific version of Collision only during development, not when installing the plugin.
- Require a release version of Type Extensions instead of `main`.
