### PR TITLE
Fix "Pin a Post" button margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.6.2 - 2024-02-08
+
+- Bug Fix: Add intentional spacing before PostPicker buttons.
+
 ## 1.6.1 - 2024-02-02
 
 - Make nunomaduro/collision a dev dependency.

--- a/blocks/post/index.scss
+++ b/blocks/post/index.scss
@@ -11,7 +11,7 @@
   }
 
   &__post-picker {
-    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
     text-align: right;
   }
 }

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.6.1
+ * Version: 1.6.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
This is a follow-up to #123.

Previously, the PostPicker appeared above the the InnerBlocks and some added margin was added below the buttons. Now that the buttons appear below, that margin should be applied to the top of the buttons container. 