### PR TITLE
Issue-133: Posts pinned twice in same Query block cause empty slot at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.6.3 - 2024-02-14
+
+- Bug Fix: Selecting a post more than once in a Query block causes empty slots at the end.
+
 ## 1.6.2 - 2024-02-08
 
 - Bug Fix: Add intentional spacing before PostPicker buttons.

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -55,6 +55,10 @@ export default function Edit({
 
   const updatePost = (post: number | null) => {
     const newPosts = [...posts];
+    // If the post is already in the list, remove it.
+    if (post !== null && newPosts.includes(post)) {
+      newPosts.splice(newPosts.indexOf(post), 1, null);
+    }
     newPosts[index] = post;
     // @ts-ignore
     dispatch('core/block-editor').updateBlockAttributes(queryParentId, {

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -200,6 +200,11 @@ export default function Edit({
 
   const setManualPost = (id: number, index: number) => {
     const newManualPosts = [...manualPosts];
+    // If the post is already in the list, remove it.
+    if (newManualPosts.includes(id)) {
+      const existing = newManualPosts.indexOf(id);
+      newManualPosts.splice(existing, 1, null);
+    }
     newManualPosts.splice(index, 1, id);
     setAttributes({ posts: newManualPosts });
   };

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -201,7 +201,7 @@ export default function Edit({
   const setManualPost = (id: number, index: number) => {
     const newManualPosts = [...manualPosts];
     // If the post is already in the list, remove it.
-    if (newManualPosts.includes(id)) {
+    if (id !== null && newManualPosts.includes(id)) {
       newManualPosts.splice(newManualPosts.indexOf(id), 1, null);
     }
     newManualPosts.splice(index, 1, id);

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -202,8 +202,7 @@ export default function Edit({
     const newManualPosts = [...manualPosts];
     // If the post is already in the list, remove it.
     if (newManualPosts.includes(id)) {
-      const existing = newManualPosts.indexOf(id);
-      newManualPosts.splice(existing, 1, null);
+      newManualPosts.splice(newManualPosts.indexOf(id), 1, null);
     }
     newManualPosts.splice(index, 1, id);
     setAttributes({ posts: newManualPosts });

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.6.2
+ * Version: 1.6.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
### Fixes Issue

Posts pinned twice in same Query block cause empty slot at the end. ([#133](https://github.com/alleyinteractive/wp-curate/issues/133))

### Description of the Change

- Implement a check in the Query block's edit function to handle the scenario where the same post is pinned more than once. This ensures that when a post is selected for a particular slot, it is immediately removed from any other slot it was previously occupying, thus preventing an empty slot from appearing at the end of the Query block. Additional improvements include cleaner code and null checks to ensure robust handling of edge cases.

### Steps to Reproduce the Issue

1. Add a Query block
2. Pin the same post twice
3. Observe an empty slot at the end in both the editor and on the front end.

### Proposed Fix

As suggested by [@mogmarsh](https://github.com/mogmarsh), the fix involves updating the block edit function. If the post list is currently `[1, 2, 3, 4]` and post `4` is selected for the first slot, it would immediately remove it from the 4th spot, resulting in the arrangement `[4, 2, 3, _]`. This change addresses the issue by ensuring that a post can only be pinned in one slot at a time. Further code cleanup and null checks have been implemented for enhanced stability and readability.