### PR TITLE
Bug Fix: Query block not updating with custom post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.7.1 - 2024-03-13
+
+- Bug Fix: Query block does not update with posts from custom post types when selected in Query Paramaters block settings.
+
 ## 1.7.0 - 2024-03-06
 
 - Enhancement: Integration with [Parse.ly plugin](https://wordpress.org/plugins/wp-parsely/) to support querying trending posts.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -161,7 +161,7 @@ export default function Edit({
         {
           search: debouncedSearchTerm,
           offset,
-          type: postTypeString,
+          post_type: postTypeString,
           status: 'publish',
           per_page: 20,
           orderby,

--- a/src/features/class-rest-api.php
+++ b/src/features/class-rest-api.php
@@ -24,6 +24,7 @@ final class Rest_Api implements Feature {
 	 */
 	public function boot(): void {
 		add_action( 'rest_api_init', [ $this, 'register_endpoints' ] );
+		add_filter( 'rest_post_query', [ $this, 'add_type_param' ], 10, 2 );
 	}
 
 	/**
@@ -141,5 +142,25 @@ final class Rest_Api implements Feature {
 			$posts = $query->posts;
 		}
 		return array_map( 'intval', $posts ); // @phpstan-ignore-line
+	}
+
+	/**
+	 * Add post_type to rest post query if the type param is set.
+	 *
+	 * @param array<array<int, string>|string> $query_args The existing query args.
+	 * @param WP_REST_Request                  $request The REST request.
+	 * @return array<array<int, string>|string>
+	 */
+	// @phpstan-ignore-next-line
+	public function add_type_param( $query_args, $request ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+		$type = $request->get_param( 'type' );
+
+		if ( ! empty( $type ) && is_string( $type ) ) {
+			$types                   = explode( ',', $type );
+			$types                   = array_filter( $types, 'post_type_exists' );
+			$query_args['post_type'] = $types;
+		}
+
+		return $query_args;
 	}
 }

--- a/src/features/class-rest-api.php
+++ b/src/features/class-rest-api.php
@@ -147,12 +147,23 @@ final class Rest_Api implements Feature {
 	/**
 	 * Add post_type to rest post query if the type param is set.
 	 *
+	 * NOTE: This is a temporary solution that will be replaced by a more robust solution in the future.
+	 *
 	 * @param array<array<int, string>|string> $query_args The existing query args.
 	 * @param WP_REST_Request                  $request The REST request.
 	 * @return array<array<int, string>|string>
 	 */
 	// @phpstan-ignore-next-line
 	public function add_type_param( $query_args, $request ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+		// Check if the user is logged in.
+		if ( ! \is_user_logged_in() ) {
+			return $query_args;
+		}
+		// Check the context.
+		if ( 'edit' !== $request['context'] ) {
+			return $query_args;
+		}
+
 		$type = $request->get_param( 'type' );
 
 		if ( ! empty( $type ) && is_string( $type ) ) {

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.7.0
+ * Version: 1.7.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
- Fixes missing param value `Rest_Api::get_post` request
- Fixes lost support for custom post types when building query parameters in Query block