### PR TITLE
Issue-159: Fatal on front end when trending is set as source but parsely not setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.8.1 - 2024-03-27
+
+- Bug Fix: Query blocks set to ordery trending fatal when Parse.ly is not set up.
+
 ## 1.8.0 - 2024-03-19
 
 - Enhancement: Integration with [WPGraphQL plugin](https://wordpress.org/plugins/wp-graphql/) to support custom GraphQL interface type and connection.

--- a/src/features/class-parsely-support.php
+++ b/src/features/class-parsely-support.php
@@ -60,6 +60,10 @@ final class Parsely_Support implements Feature {
 	 * @return array<int> An array of post IDs.
 	 */
 	public function get_trending_posts( array $args ): array {
+		$parsely = $GLOBALS['parsely'];
+		if ( ! $parsely->api_secret_is_set() ) {
+			return [];
+		}
 		if ( ! class_exists( '\Parsely\Parsely' ) || ! isset( $GLOBALS['parsely'] ) || ! $GLOBALS['parsely'] instanceof Parsely ) {
 			return [];
 		}

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
### Fixes Issue
[#159](https://github.com/alleyinteractive/wp-curate/issues/159) - Fatal on front end when trending is set as source but parsely not setup

I will add the version bump and changelog shortly.

### Description of the Change

- Viewing a Query block that has trending set for the source results in an error on the front end if parsely is not set up.

### Steps To Reproduce

1. Set up a Query block and in the code view set orderby to trending

```html
<!-- wp:wp-curate/query {"deduplication":"never","numberOfPosts":4,"posts":[null,null,null,null],"orderby":"trending"} -->
<div class="wp-block-wp-curate-query"><!-- wp:post-template -->
<!-- wp:wp-curate/post -->
<div class="wp-block-wp-curate-post"><!-- wp:columns {"isStackedOnMobile":false} -->
<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"60%"} -->
<div class="wp-block-column" style="flex-basis:60%"><!-- wp:post-title {"level":3,"isLink":true} /-->

<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
<div class="wp-block-group"><!-- wp:post-date {"format":"M j, Y g:i A", "timediff": true} /-->

<!-- wp:mediaco/primary-term {"isLink":false} /--></div>
<!-- /wp:group --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"40%"} -->
<div class="wp-block-column" style="flex-basis:40%"><!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9","style":{"layout":{"selfStretch":"fixed","flexSize":"50%"}}} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:wp-curate/post -->
<!-- /wp:post-template --></div>
<!-- /wp:wp-curate/query -->
```

2. Make sure parsely is not configured.
3. View it on the front end.

### Additional Information

_No response_
