### PR TITLE
Issue-173: autoselect post types if posts are not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 1.9.1 - 2024-04-25
+
+- Bug Fix: Improve handling of default post types on the Query block.
+
 ## 1.9.0 - 2024-04-19
 
 - Enhancement: Exclude current post in backfilled posts query.

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -45,9 +45,7 @@
       "type": "number"
     },
     "postTypes": {
-      "default": [
-        "post"
-      ],
+      "default": [],
       "items": {
         "type": "string"
       },

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -65,7 +65,7 @@ export default function Edit({
     numberOfPosts = 5,
     offset = 0,
     posts: manualPosts = [],
-    postTypes = ['post'],
+    postTypes = [],
     searchTerm = '',
     terms = {},
     termRelations = {},
@@ -81,6 +81,10 @@ export default function Edit({
       parselyAvailable = 'false',
     } = {},
   } = (window as any as Window);
+
+  if (!postTypes.length) {
+    setAttributes({ postTypes: allowedPostTypes });
+  }
 
   const andOrOptions = [
     {

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 1.9.0
+ * Version: 1.9.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
### Summary

Fixes #173 - When posts are not enabled, the enabled post types should now be checked by default in the sidebar, ensuring the block loads content immediately upon addition to the editor. This update modifies the behavior of default post types to address this issue more effectively.

### Description

This PR addresses the issue where, if posts are not enabled, no enabled post types were checked by default in the sidebar. As a result, the block did not load any content by default when added to the editor. The fix ensures that there's always a default selection for the enabled post types, allowing content to load without additional user input. The behavior of selecting default post types has been changed to improve this functionality.

### Steps To Test

1. Disable support for posts with `wp_curate_allowed_post_types`.
2. Add a Query block to the editor.
3. Verify that the block loads content by default, indicating that the first enabled post type is selected automatically.

### Additional Information

_No additional information provided._

For more details, see the original issue [here](https://github.com/alleyinteractive/wp-curate/issues/173).