### PR TITLE
Add filters for query args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## Unreleased
+
+- Enhancement: Add `wp_curate_plugin_curated_post_query` filter for the arguments used for querying posts that match query block attributes.
+- Enhancement: Add `wp_curate_rest_posts_query` filter for the arguments used for querying posts over the REST API for the query block editor preview.
+- Enhancement: Make the ID of the post being edited available to `wp_curate_rest_posts_query` filter.
+
 ## 1.9.1 - 2024-04-25
 
 - Bug Fix: Improve handling of default post types on the Query block.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -170,6 +170,7 @@ export default function Edit({
           status: 'publish',
           per_page: 20,
           orderby,
+          current_post_id: Number.isInteger(currentPostId) ? currentPostId : 0,
         },
       );
       path += `&${termQueryArgs}`;

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -81,6 +81,13 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 			origin: $this->queries,
 		);
 
+		/**
+		 * Filters the arguments used when querying for posts that match the block attributes.
+		 *
+		 * @param array<string, mixed> $args Query arguments.
+		 */
+		$args = apply_filters( 'wp_curate_plugin_curated_post_query', $args );
+
 		$context['query'] = [
 			'perPage'  => $args['posts_per_page'],
 			'include'  => $queries->query( $args )->post_ids(),

--- a/src/features/class-rest-api.php
+++ b/src/features/class-rest-api.php
@@ -40,6 +40,13 @@ final class Rest_Api implements Feature {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_posts' ],
 				'permission_callback' => 'is_user_logged_in',
+				'args'                => [
+					'current_post_id' => [
+						'type'        => 'integer',
+						'description' => __( 'The ID of the post being edited, if any.', 'wp-curate' ),
+						'default'     => 0,
+					],
+				],
 			]
 		);
 	}

--- a/src/features/class-rest-api.php
+++ b/src/features/class-rest-api.php
@@ -128,6 +128,14 @@ final class Rest_Api implements Feature {
 			$args['tax_query'] = $tax_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
 
+		/**
+		 * Filters the REST post query arguments.
+		 *
+		 * @param array<string, mixed> $args    The WP_Query arguments.
+		 * @param WP_REST_Request      $request The REST request.
+		 */
+		$args = apply_filters( 'wp_curate_rest_posts_query', $args, $request );
+
 		if ( $trending ) {
 			/**
 			 * Filters the trending posts query.


### PR DESCRIPTION
Adds filters for the query arguments used in the frontend and backend. The `current_post_id` parameter makes it possible to determine when the post being edited is also used as the site's front page.