### PR TITLE
Issue-190: Block Error with TwentyTwentyFour Theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.0.1 - 2024-07-18
+
+- Bug Fix: Update block-editor-tools to prevent errors/block crashes related to the PostPicker.
+
 ## 2.0.0 - 2024-06-24
 
 - Enhancement: Fire the `wp_curate_clear_history_post_ids` action to clear the history of post IDs that have used on the page and would be deduplicated from subsequent queries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@alleyinteractive/block-editor-tools": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@alleyinteractive/block-editor-tools/-/block-editor-tools-0.10.0.tgz",
-      "integrity": "sha512-xqobLKI/AC5rzvAofzzs7QUw8gJZ1+cj/1kGRlBhh26lG7HxDrCgMkRT5ERMslvSnEyGbXpJTJnjoC3wDWLedQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@alleyinteractive/block-editor-tools/-/block-editor-tools-0.10.2.tgz",
+      "integrity": "sha512-QXiCOaJTvdPuhTElJ68bJF1io7iyx4+kRj4Yt6asB88LbIbBnkbOgDcQQN2w7wq0McHpGrisEbeY35WUwVorMw==",
       "engines": {
         "node": ">=16.0.0 <21.0.0",
         "npm": ">=8.0.0"

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
## Summary
Fixes #190

## Description of the changes
<!-- Please provide a detailed description of the changes made in this pull request. -->
- Updated block editor tools to address the block error when using the TwentyTwentyFour theme.

## Steps to Test
<!-- Please provide detailed steps for testing and reviewing this pull request. -->
1. Create a new WordPress test site using the Twenty Twenty-Four theme and don't add any other plugins.  The site should be a standalone vanilla install.
2. Install the latest tagged version of wp-curate.  I downloaded the zip for version 1.10.0 and installed and activated the plugin through the WordPress admin.
3. Navigate to the Site Editor. Create a new template.
4. Add the Query block and then click on one of the posts to select a post.
5. Verify that the error no longer appears and a post can be selected without issue.

## Additional Information
<!-- If there is any additional information that you think would be useful to include in this pull request, please add it here. -->