### PR TITLE
Add custom Post Title block - store attributes in Query block

### DIFF
--- a/blocks/post-title/block.json
+++ b/blocks/post-title/block.json
@@ -10,19 +10,11 @@
   "textdomain": "wp-curate",
   "editorScript": "file:index.ts",
   "style": "wp-block-post-title",
-  "usesContext": ["postId", "query", "pinnedPosts"],
+  "usesContext": ["postId", "query", "pinnedPosts", "customPostTitles"],
   "attributes": {
     "level": {
       "type": "number",
       "default": 3
-    },
-    "customPostTitles": {
-      "default": [],
-      "items": {
-        "default": {},
-        "type": "object"
-      },
-      "type": "array"
     }
   },
   "render": "file:render.php",

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -55,8 +55,6 @@ export default function Edit({
   const TagName = level === 0 ? 'p' : `h${level}`;
   const blockProps = useBlockProps();
 
-  console.log('mre', context);
-
   useEffect(() => {
     /**
      * Handle case for removing custom title from collection if post is unpinned.

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -3,15 +3,12 @@ import { InspectorControls, PlainText, useBlockProps } from '@wordpress/block-ed
 import { useEntityProp } from '@wordpress/core-data';
 import { useEffect } from 'react';
 import { PanelBody, SelectControl } from '@wordpress/components';
+import { dispatch, select } from '@wordpress/data';
 
 interface PostTitleEditProps {
   clientId?: string;
   attributes: {
     level?: number;
-    customPostTitles?: {
-      postId: number;
-      title: string;
-    }[];
   };
   context: {
     postId: number;
@@ -23,6 +20,10 @@ interface PostTitleEditProps {
       orderby?: string;
     };
     pinnedPosts?: Array<number>;
+    customPostTitles?: {
+      postId: number;
+      title: string;
+    }[];
   };
   isSelected?: boolean;
   setAttributes: (attributes: any) => void;
@@ -34,18 +35,27 @@ interface PostTitleEditProps {
  * @return {WPElement} Element to render.
  */
 export default function Edit({
+  clientId,
   attributes,
   context,
   setAttributes,
 }: PostTitleEditProps) {
   // @ts-ignore
-  const { postId, pinnedPosts = [], query: { postType = 'post' } } = context;
-  const { customPostTitles = [], level = 3 } = attributes;
+  const queryParentId = select('core/block-editor').getBlockParentsByBlockName(clientId, 'wp-curate/query')[0];
+  const {
+    postId,
+    pinnedPosts = [],
+    query: { postType = 'post' },
+    customPostTitles = [],
+  } = context;
+  const { level = 3 } = attributes;
   const [rawTitle = '', , fullTitle] = useEntityProp('postType', postType, 'title', postId.toString());
   const isPinned = pinnedPosts.includes(postId);
   const currentCustomPostTitle = customPostTitles.find((item) => item?.postId === postId);
   const TagName = level === 0 ? 'p' : `h${level}`;
   const blockProps = useBlockProps();
+
+  console.log('mre', context);
 
   useEffect(() => {
     /**
@@ -55,11 +65,11 @@ export default function Edit({
       customPostTitles.length
       && (currentCustomPostTitle && !isPinned)
     ) {
-      setAttributes(
-        { customPostTitles: customPostTitles.filter((item) => item?.postId !== postId) },
-      );
+      dispatch('core/block-editor').updateBlockAttributes(queryParentId, {
+        customPostTitles: customPostTitles.filter((item) => item?.postId !== postId),
+      });
     }
-  }, [isPinned, postId, customPostTitles, currentCustomPostTitle, setAttributes]);
+  }, [isPinned, postId, customPostTitles, currentCustomPostTitle, setAttributes, queryParentId]);
 
   const handleOnChange = (title: string) => {
     /**
@@ -69,9 +79,9 @@ export default function Edit({
     if (
       (currentCustomPostTitle?.postId && currentCustomPostTitle?.title.length === 0)
       && title === rawTitle) {
-      setAttributes(
-        { customPostTitles: customPostTitles.filter((item) => item?.postId !== postId) },
-      );
+      dispatch('core/block-editor').updateBlockAttributes(queryParentId, {
+        customPostTitles: customPostTitles.filter((item) => item?.postId !== postId),
+      });
       return;
     }
 
@@ -101,7 +111,9 @@ export default function Edit({
       ];
     }
 
-    setAttributes({ customPostTitles: newCustomPostTitles });
+    dispatch('core/block-editor').updateBlockAttributes(queryParentId, {
+      customPostTitles: newCustomPostTitles,
+    });
   };
 
   let titleElement = (

--- a/blocks/post-title/render.php
+++ b/blocks/post-title/render.php
@@ -15,11 +15,16 @@
 
 $current_post_id = intval( $block->context['postId'] );
 
+echo '<pre>';
+var_dump( $block->context );
+echo '</pre>';
+
+
 if ( empty( $current_post_id ) ) {
 	return;
 }
 
-$custom_post_titles = is_array( $attributes['customPostTitles'] ) ? $attributes['customPostTitles'] : [];
+$custom_post_titles = ! empty( $attributes['customPostTitles'] ) ? $attributes['customPostTitles'] : [];
 $post_title         = get_the_title( $current_post_id );
 $post_link          = get_the_permalink( $current_post_id );
 $level              = intval( $attributes['level'] );

--- a/blocks/post-title/render.php
+++ b/blocks/post-title/render.php
@@ -15,16 +15,11 @@
 
 $current_post_id = intval( $block->context['postId'] );
 
-echo '<pre>';
-var_dump( $block->context );
-echo '</pre>';
-
-
 if ( empty( $current_post_id ) ) {
 	return;
 }
 
-$custom_post_titles = ! empty( $attributes['customPostTitles'] ) ? $attributes['customPostTitles'] : [];
+$custom_post_titles = ! empty( $block->context['customPostTitles'] ) ? $block->context['customPostTitles'] : [];
 $post_title         = get_the_title( $current_post_id );
 $post_link          = get_the_permalink( $current_post_id );
 $level              = intval( $attributes['level'] );

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -18,7 +18,8 @@
     "displayLayout": "displayLayout",
     "heading": "heading",
     "curation": "curation",
-    "pinnedPosts": "posts"
+    "pinnedPosts": "posts",
+    "customPostTitles": "customPostTitles"
   },
   "attributes": {
     "deduplication": {
@@ -101,6 +102,14 @@
         "trending"
       ],
       "type": "string"
+    },
+    "customPostTitles": {
+      "default": [],
+      "items": {
+        "default": {},
+        "type": "object"
+      },
+      "type": "array"
     }
   }
 }

--- a/src/features/class-query-block-context.php
+++ b/src/features/class-query-block-context.php
@@ -28,6 +28,14 @@ use WP_Block_Type_Registry;
  * Provides context to query blocks
  */
 final class Query_Block_Context implements Feature {
+
+	/**
+	 * Custom post titles associated with Query.
+	 *
+	 * @var array
+	 */
+	private array $custom_post_titles = [];
+
 	/**
 	 * Set up.
 	 *
@@ -151,6 +159,34 @@ final class Query_Block_Context implements Feature {
 			&& ! isset( $context['query'] )
 		) {
 			$context['query'] = $parent_block->context['query'];
+		}
+
+		/**
+		 * In addition to having access to the query context for the said reason above, also
+		 * ensure that the `wp-curate/post-title` block has access to custom post titles
+		 * in it's context.
+		 *
+		 * This is necessary due to filtering that happens in core which forces only post ID and
+		 * post type to be available.
+		 *
+		 * See: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/post-template/index.php#L113
+		 */
+		if (
+			$parent_block instanceof WP_Block
+			&& $current_block_type instanceof WP_Block_Type
+			&& $plugin_block_type instanceof WP_Block_Type
+			&& $parent_block->name === $plugin_block_type->name
+			&& in_array( 'query', $current_block_type->uses_context, true ) // @phpstan-ignore-line - uses_context is private in WP_Block_Type but can be accessed via a magic method.
+			&& $current_block->block_name() === 'core/post-template'
+			&& $parent_block->name === 'wp-curate/query'
+			&& isset ( $parent_block->attributes['customPostTitles'] )
+		) {
+			$this->custom_post_titles = $parent_block->attributes['customPostTitles'];
+		}
+
+		// Manually assign custom post titles to 'wp-curate/post-title' context.
+		if ( $current_block->block_name() === 'wp-curate/post-title' && ! empty ( $this->custom_post_titles ) ) {
+			$context['customPostTitles'] = $this->custom_post_titles;
 		}
 
 		return $context;


### PR DESCRIPTION
This PR builds on #208 and moves the custom post titles attribute from the Post Title block to the Query block. 