### PR TITLE
Enhancement - Add Filter for Post Title Heading Level Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.2.3 - 2024-08-22
+
+- Enhancement: Enable block filter support for Post Title block setting Heading Level select.
+
 ## 2.2.2 - 2024-08-21
 
 - Enhancement: Introduce `SWR` for caching API requests in the Query block.
 
 ## 2.2.1 - 2024-08-15
 
- - Bug Fix: Handle cases where a pinned post has been deleted or unpublished.
+- Bug Fix: Handle cases where a pinned post has been deleted or unpublished.
 
 ## 2.2.0 - 2024-08-05
 

--- a/blocks/post-title/block.json
+++ b/blocks/post-title/block.json
@@ -19,7 +19,7 @@
     "supportsLevel": {
       "type": "boolean",
       "default": true
-    },
+    }
   },
   "render": "file:render.php",
   "supports": {

--- a/blocks/post-title/block.json
+++ b/blocks/post-title/block.json
@@ -15,7 +15,11 @@
     "level": {
       "type": "number",
       "default": 3
-    }
+    },
+    "supportsLevel": {
+      "type": "boolean",
+      "default": true
+    },
   },
   "render": "file:render.php",
   "supports": {

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -147,15 +147,15 @@ export default function Edit({
   return (
     <>
       { titleElement }
-      <InspectorControls>
-        <PanelBody
-          title={__('Setup', 'wp-curate')}
-          initialOpen
-        >
-          {supportsLevel ? (
+      {supportsLevel ? (
+        <InspectorControls>
+          <PanelBody
+            title={__('Setup', 'wp-curate')}
+            initialOpen
+          >
             <SelectControl
               label={__('Heading Level')}
-            // @ts-ignore
+              // @ts-ignore
               value={level.toString()}
               options={[
                 { label: 'p', value: '0' },
@@ -170,9 +170,9 @@ export default function Edit({
                 setAttributes({ level: parseInt(newLevel, 10) });
               }}
             />
-          ) : null }
-        </PanelBody>
-      </InspectorControls>
+          </PanelBody>
+        </InspectorControls>
+      ) : null}
     </>
   );
 }

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -9,6 +9,7 @@ interface PostTitleEditProps {
   clientId?: string;
   attributes: {
     level?: number;
+    supportsLevel?: boolean;
   };
   context: {
     postId: number;
@@ -48,11 +49,11 @@ export default function Edit({
     query: { postType = 'post' },
     customPostTitles = [],
   } = context;
-  const { level = 3 } = attributes;
+  const { level = 3, supportsLevel } = attributes;
   const [rawTitle = '', , fullTitle] = useEntityProp('postType', postType, 'title', postId.toString());
   const isPinned = pinnedPosts.includes(postId);
   const currentCustomPostTitle = customPostTitles.find((item) => item?.postId === postId);
-  const TagName = level === 0 ? 'p' : `h${level}`;
+  const TagName = !supportsLevel || level === 0 ? 'p' : `h${level}`;
   const blockProps = useBlockProps();
 
   useEffect(() => {
@@ -151,23 +152,25 @@ export default function Edit({
           title={__('Setup', 'wp-curate')}
           initialOpen
         >
-          <SelectControl
-            label={__('Heading Level')}
+          {supportsLevel ? (
+            <SelectControl
+              label={__('Heading Level')}
             // @ts-ignore
-            value={level.toString()}
-            options={[
-              { label: 'p', value: '0' },
-              { label: 'h1', value: '1' },
-              { label: 'h2', value: '2' },
-              { label: 'h3', value: '3' },
-              { label: 'h4', value: '4' },
-              { label: 'h5', value: '5' },
-              { label: 'h6', value: '6' },
-            ]}
-            onChange={(newLevel) => {
-              setAttributes({ level: parseInt(newLevel, 10) });
-            }}
-          />
+              value={level.toString()}
+              options={[
+                { label: 'p', value: '0' },
+                { label: 'h1', value: '1' },
+                { label: 'h2', value: '2' },
+                { label: 'h3', value: '3' },
+                { label: 'h4', value: '4' },
+                { label: 'h5', value: '5' },
+                { label: 'h6', value: '6' },
+              ]}
+              onChange={(newLevel) => {
+                setAttributes({ level: parseInt(newLevel, 10) });
+              }}
+            />
+          ) : null }
         </PanelBody>
       </InspectorControls>
     </>

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.2.3
+ * Version: 2.3.0
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
# Summary

Provides ability within projects to disable the Heading Level dropdown from the Post Title block settings. 

Example

```
wp.hooks.addFilter( 'blocks.registerBlockType', 'wp-curate/example', ( settings, name ) => {
    const maybeFilteredSettings = { ...settings };

    if( 'wp-curate/post-title' === name ) {
        maybeFilteredSettings.attributes.supportsLevel.default = false;
    }

    return maybeFilteredSettings
});
```