### PR TITLE
Hotfix/fix async dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.2.4 - 2024-08-26
+
+- Bug Fix: Backfill posts filling out of order in the Editor.
+
 ## 2.2.2 - 2024-08-21
 
 - Enhancement: Introduce `SWR` for caching API requests in the Query block.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -227,10 +227,10 @@ export default function Edit({
       }
 
       setAttributes({ validPosts });
+      mainDedupe();
     };
     updateValidPosts();
   }, [manualPosts, setAttributes]);
-
 
   const setManualPost = (id: number, index: number) => {
     const newManualPosts = [...manualPosts];

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -22,8 +22,11 @@ import {
   useState,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 import { Template } from '@wordpress/blocks';
+import type { WP_REST_API_Posts as WpRestApiPosts } from 'wp-types'; // eslint-disable-line camelcase
+
 import type {
   EditProps,
   Option,
@@ -200,6 +203,34 @@ export default function Edit({
     data,
     error,
   ]);
+
+  // Make sure all the manual posts are still valid.
+  useEffect(() => {
+    const updateValidPosts = async () => {
+      const postsToInclude = manualPosts.filter((id) => id !== null).join(',');
+      let validPosts: Number[] = [];
+
+      if (postsToInclude.length > 0) {
+        validPosts = await apiFetch({
+          path: addQueryArgs(
+            '/wp/v2/posts',
+            {
+              offset: 0,
+              orderby: 'include',
+              per_page: postsToInclude.length,
+              type: 'post',
+              include: postsToInclude,
+              _locale: 'user',
+            },
+          ),
+        }).then((response) => (response as any as WpRestApiPosts).map((post) => post.id));
+      }
+
+      setAttributes({ validPosts });
+    };
+    updateValidPosts();
+  }, [manualPosts, setAttributes]);
+
 
   const setManualPost = (id: number, index: number) => {
     const newManualPosts = [...manualPosts];

--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -1,7 +1,4 @@
 import { select, dispatch } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
-import type { WP_REST_API_Posts as WpRestApiPosts } from 'wp-types'; // eslint-disable-line camelcase
 
 const usedIds = new Map();
 const curatedIds = new Map();
@@ -19,6 +16,7 @@ interface Block {
     query?: {
       include?: number[];
     }
+    validPosts?: number[];
   },
   clientId: string;
   name: string;
@@ -84,7 +82,7 @@ const getQueryBlocks = (blocks: Block[], out: Block[]) => {
  * This is the main function to update all pinned posts. Call it whenever a pinned post
  * changes or the query settings change.
  */
-export async function mainDedupe() {
+export function mainDedupe() {
   if (running) {
     // Only one run at a time, but mark that another run has been requested.
     redo = true;
@@ -121,7 +119,7 @@ export async function mainDedupe() {
   }
 
   // Loop through all query blocks and set backfilled posts in the open slots.
-  queryBlocks.forEach(async (queryBlock) => {
+  queryBlocks.forEach((queryBlock) => {
     const { attributes } = queryBlock;
     const {
       backfillPosts = null,
@@ -129,30 +127,11 @@ export async function mainDedupe() {
       posts = [],
       numberOfPosts = 5,
       postTypes = ['post'],
+      validPosts = [],
     } = attributes;
     if (!backfillPosts) {
       return;
     }
-
-    const postsToInclude = posts.filter((id) => id !== null).join(',');
-    let validPosts: Number[] = [];
-
-    if (postsToInclude.length > 0) {
-      validPosts = await apiFetch({
-        path: addQueryArgs(
-          '/wp/v2/posts',
-          {
-            offset: 0,
-            orderby: 'include',
-            per_page: posts.length,
-            type: 'post',
-            include: postsToInclude,
-            _locale: 'user',
-          },
-        ),
-      }).then((response) => (response as any as WpRestApiPosts).map((post) => post.id));
-    }
-
     const postTypeString = postTypes.join(',');
     let postIndex = 0;
 

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.2.2
+ * Version: 2.2.4
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
Move the manual post validation from mainDedupe() to a useEffect() in the query block edit. This prevents the posts from getting backfilled out of order.