### PR TITLE
Skip deduplication during block transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.3.2 - 2024-09-09
+
+- Bug Fix: Prevent block transforms from crashing the Query block.
+
 ## 2.3.1 - 2024-08-28
 
 - Bug Fix: Backfill posts filling out of order in the Editor.

--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -89,6 +89,11 @@ export function mainDedupe() {
     return;
   }
 
+  // If the block transforms menu is currently open, skip deduplication.
+  if (document.querySelector('.block-editor-block-switcher__popover__preview__parent')) {
+    return;
+  }
+
   running = true;
   // Clear the flag for another run.
   redo = false;

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.3.1
+ * Version: 2.3.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
Addresses #230 by preventing deduplication from running when the transforms preview element is present.