### PR TITLE
Hotfix/unpublished posts filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.3.3 - 2024-09-16
+
+- Bug Fix: Hold space on the front end for curated posts that were deleted.
+
 ## 2.3.2 - 2024-09-09
 
 - Bug Fix: Prevent block transforms from crashing the Query block.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18498,11 +18498,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -19668,9 +19668,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -74,9 +74,9 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		}
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
-		$pinned_posts = array_filter( $pinned_posts, function ( $id ) {
-			return 'publish' === get_post_status( $id );
-		} );
+		$pinned_posts = array_map( function ( $id ) {
+			return 'publish' === get_post_status( $id ) ? $id : null;
+		}, $pinned_posts );
 
 		$queries = new Positioned_Post_Queries(
 			positioned: is_array( $pinned_posts ) ? $pinned_posts : [],

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -74,12 +74,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		}
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
-		$pinned_posts = array_map( function ( $id ) {
-			if ( ! $id ) {
-				return null;
-			}
-			return 'publish' === get_post_status( $id ) ? $id : null;
-		}, $pinned_posts );
+		$pinned_posts = array_map( fn ( $id ) => $id && 'publish' === get_post_status( $id ) ? $id : null, $pinned_posts );
 
 		$queries = new Positioned_Post_Queries(
 			positioned: is_array( $pinned_posts ) ? $pinned_posts : [],

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -77,7 +77,7 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 		$pinned_posts = array_map( fn ( $id ) => $id && 'publish' === get_post_status( $id ) ? $id : null, $pinned_posts );
 
 		$queries = new Positioned_Post_Queries(
-			positioned: is_array( $pinned_posts ) ? $pinned_posts : [],
+			positioned: $pinned_posts,
 			default_per_page: $args['posts_per_page'],
 			origin: $this->queries,
 		);

--- a/src/class-plugin-curated-posts.php
+++ b/src/class-plugin-curated-posts.php
@@ -75,6 +75,9 @@ final class Plugin_Curated_Posts implements Curated_Posts {
 
 		$pinned_posts = $attributes['posts'] ?? $block_type->attributes['posts']['default'];
 		$pinned_posts = array_map( function ( $id ) {
+			if ( ! $id ) {
+				return null;
+			}
 			return 'publish' === get_post_status( $id ) ? $id : null;
 		}, $pinned_posts );
 

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.3.2
+ * Version: 2.3.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
use `array_map` instead of `array_filter` so we hold the space for curated posts that were deleted