### PR TITLE
Enhancement - Enable support for hiding post type selection from block settings UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.5.0 - 2024-09-17
+
+- Enhancement: Enable support for hiding post type selection from block settings UI.
+
 ## 2.4.0 - 2024-08-28
 
 - Enhancement: Subquery block added to allow a separate set of posts within a query block.
-see https://github.com/alleyinteractive/wp-curate/issues/200
+see <https://github.com/alleyinteractive/wp-curate/issues/200>
 
 ## 2.3.3 - 2024-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
-## 2.5.0 - 2024-09-17
+## 2.4.1 - 2024-09-19
 
 - Enhancement: Enable support for hiding post type selection from block settings UI.
 

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -108,7 +108,7 @@
       },
       "type": "array"
     },
-    "hidePostTypes": {
+    "supportsPostTypes": {
       "default": [],
       "items": {
         "default": "",

--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -107,6 +107,14 @@
         "type": "object"
       },
       "type": "array"
+    },
+    "hidePostTypes": {
+      "default": [],
+      "items": {
+        "default": "",
+        "type": "string"
+      },
+      "type": "array"
     }
   }
 }

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -62,6 +62,7 @@ export default function Edit({
     taxRelation = 'AND',
     orderby = 'date',
     moveData = {},
+    hidePostTypes = [],
   },
   clientId,
   setAttributes,
@@ -223,10 +224,12 @@ export default function Edit({
     ],
   ];
 
-  const displayTypes: Option[] = allowedPostTypes.map((type) => ({
-    label: type.name,
-    value: type.slug,
-  }));
+  const displayTypes: Option[] = allowedPostTypes
+    .map((type) => ({
+      label: type.name,
+      value: type.slug,
+    }))
+    .filter((type) => !hidePostTypes.includes(type.value));
 
   return (
     <>

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -230,10 +230,12 @@ export default function Edit({
       value: type.slug,
     }))
     .filter((type) => {
+      // Inherits globally supported post types if attribute is empty.
       if (!supportsPostTypes.length) {
         return true;
       }
 
+      // Display only supported post types defined by block.
       return supportsPostTypes.includes(type.value);
     });
 

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -62,7 +62,7 @@ export default function Edit({
     taxRelation = 'AND',
     orderby = 'date',
     moveData = {},
-    hidePostTypes = [],
+    supportsPostTypes = [],
   },
   clientId,
   setAttributes,
@@ -229,7 +229,13 @@ export default function Edit({
       label: type.name,
       value: type.slug,
     }))
-    .filter((type) => !hidePostTypes.includes(type.value));
+    .filter((type) => {
+      if (!supportsPostTypes.length) {
+        return true;
+      }
+
+      return supportsPostTypes.includes(type.value);
+    });
 
   return (
     <>

--- a/blocks/query/types.ts
+++ b/blocks/query/types.ts
@@ -24,6 +24,7 @@ interface EditProps {
       clientId?: string;
     };
     uniqueId?: string;
+    supportsPostTypes?: string[];
   };
   clientId: string;
   setAttributes: (attributes: any) => void;

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.4.0
+ * Version: 2.5.0
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.5.0
+ * Version: 2.4.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
Provides a method for hiding specific post types from the Query Parameters section of the block settings UI. 

Since the configuration comes from block attributes on the Query block, it allows for more control at the individual block level when globally supported post types should not be included. 