### PR TITLE
Issue-237: `updateValidPosts` check does not pass post types and only checks for valid posts, other post types fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.4.2 - 2024-09-27
+
+- Bug Fix: Posts not of type 'post' are flagged as being deleted.
+
 ## 2.4.1 - 2024-09-19
 
 - Enhancement: Enable support for hiding post type selection from block settings UI.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -185,9 +185,10 @@ export default function Edit({
               offset: 0,
               orderby: 'include',
               per_page: postsToInclude.length,
-              type: 'post',
+              type: postTypeString,
               include: postsToInclude,
               _locale: 'user',
+              context: 'edit',
             },
           ),
         }).then((response) => (response as any as WpRestApiPosts).map((post) => post.id));
@@ -197,7 +198,7 @@ export default function Edit({
       mainDedupe();
     };
     updateValidPosts();
-  }, [manualPosts, setAttributes]);
+  }, [manualPosts, setAttributes, postTypeString]);
 
   for (let i = 0; i < numberOfPosts; i += 1) {
     if (!manualPosts[i]) {

--- a/blocks/subquery/edit.tsx
+++ b/blocks/subquery/edit.tsx
@@ -200,9 +200,10 @@ export default function Edit({
               offset: 0,
               orderby: 'include',
               per_page: postsToInclude.length,
-              type: 'post',
+              type: postTypeString,
               include: postsToInclude,
               _locale: 'user',
+              context: 'edit',
             },
           ),
         }).then((response) => (response as any as WpRestApiPosts).map((post) => post.id));
@@ -212,7 +213,7 @@ export default function Edit({
       mainDedupe();
     };
     updateValidPosts();
-  }, [manualPosts, setAttributes]);
+  }, [manualPosts, setAttributes, postTypeString]);
 
   for (let i = 0; i < numberOfPosts; i += 1) {
     if (!manualPosts[i]) {

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.4.1
+ * Version: 2.4.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
## Summary
This PR addresses the issue described in https://github.com/alleyinteractive/wp-curate/issues/237 - Fixes #237

### Description of the bug

When pinning a post from a custom post type (not post), you receive a warning that the post has been deleted and you cannot pin the post.

### Solution

The validation has been updated to allow additional post types, ensuring that posts of custom types can be pinned without triggering a deletion warning.

### Steps To Reproduce

Pin a post not of type 'post'

### Additional Information

_No response_