### PR TITLE
Issue-236: Subquery block missing support for custom post titles

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Run Node Tests
         # See https://github.com/alleyinteractive/action-test-node for more options
         uses: alleyinteractive/action-test-node@develop
+        with:
+            node-version: '20'
 
       - name: Run PHP Tests
         # See https://github.com/alleyinteractive/action-test-php for more options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `WP Curate` will be documented in this file.
 
 ## 2.4.3 - 2024-11-18
 
-- Enhancement: Post Title block (which allows override titles) works in Subquery block.
+- Enhancement: Post Title block (which allows title overrides for pinned posts) works in Subquery block.
 
 ## 2.4.2 - 2024-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.4.3 - 2024-11-18
+
+- Enhancement: Post Title block (which allows override titles) works in Subquery block.
+
 ## 2.4.2 - 2024-09-27
 
 - Bug Fix: Posts not of type 'post' are flagged as being deleted.

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -42,7 +42,9 @@ export default function Edit({
   setAttributes,
 }: PostTitleEditProps) {
   // @ts-ignore
-  const queryParentId = select('core/block-editor').getBlockParentsByBlockName(clientId, 'wp-curate/query')[0];
+  const queryParentIds = select('core/block-editor').getBlockParentsByBlockName(clientId, ['wp-curate/query', 'wp-curate/subquery']);
+  const queryParentId = queryParentIds.length ? queryParentIds[queryParentIds.length - 1] : null;
+
   const {
     postId,
     pinnedPosts = [],

--- a/blocks/subquery/block.json
+++ b/blocks/subquery/block.json
@@ -18,7 +18,13 @@
         "postId"
     ],
     "providesContext": {
-        "query": "query"
+        "query": "query",
+        "displayLayout": "displayLayout",
+        "heading": "heading",
+        "curation": "curation",
+        "pinnedPosts": "posts",
+        "moveData": "moveData",
+        "customPostTitles": "customPostTitles"
     },
     "attributes": {
         "deduplication": {
@@ -101,6 +107,14 @@
         "uniqueId": {
             "default": "",
             "type": "string"
+        },
+        "customPostTitles": {
+            "default": [],
+            "items": {
+                "default": {},
+                "type": "object"
+            },
+            "type": "array"
         }
     }
 }

--- a/blocks/subquery/block.json
+++ b/blocks/subquery/block.json
@@ -19,11 +19,7 @@
     ],
     "providesContext": {
         "query": "query",
-        "displayLayout": "displayLayout",
-        "heading": "heading",
-        "curation": "curation",
         "pinnedPosts": "posts",
-        "moveData": "moveData",
         "customPostTitles": "customPostTitles"
     },
     "attributes": {

--- a/blocks/subquery/edit.tsx
+++ b/blocks/subquery/edit.tsx
@@ -232,7 +232,7 @@ export default function Edit({
           'wp-curate/post',
           {},
           [
-            ['core/post-title', { isLink: true, level: 3 }],
+            ['wp-curate/post-title', { isLink: true, level: 3 }],
           ],
         ],
       ],

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "alleyinteractive/alley-coding-standards": "^2.0",
     "mantle-framework/testkit": "^1.1",
     "nunomaduro/collision": "^7.10",
+    "simplehtmldom/simplehtmldom": "^2.0@RC",
     "szepeviktor/phpstan-wordpress": "^1.1"
   },
   "config": {

--- a/src/features/class-query-block-context.php
+++ b/src/features/class-query-block-context.php
@@ -183,7 +183,7 @@ final class Query_Block_Context implements Feature {
 			&& $current_block_type instanceof WP_Block_Type
 			&& in_array( 'query', $current_block_type->uses_context, true ) // @phpstan-ignore-line - uses_context is private in WP_Block_Type but can be accessed via a magic method.
 			&& $current_block->block_name() === 'core/post-template'
-			&& 'wp-curate/query' === $parent_block->name
+			&& in_array( $parent_block->name, [ 'wp-curate/query', 'wp-curate/subquery' ], true )
 			&& isset( $parent_block->attributes['customPostTitles'] )
 		) {
 			$this->custom_post_titles = $parent_block->attributes['customPostTitles'];

--- a/src/post-ids/class-pinned-in-post-content.php
+++ b/src/post-ids/class-pinned-in-post-content.php
@@ -48,7 +48,7 @@ final class Pinned_In_Post_Content implements Post_IDs {
 					$query_blocks = match_blocks(
 						$post->post_content,
 						[
-							'name'       => 'wp-curate/query',
+							'name'       => [ 'wp-curate/query', 'wp-curate/subquery' ],
 							'flatten'    => true,
 							'with_attrs' => 'posts',
 						],

--- a/tests/feature/UniquePinnedPostTest.php
+++ b/tests/feature/UniquePinnedPostTest.php
@@ -8,6 +8,7 @@
 namespace Alley\WP\WP_Curate\Tests\Feature;
 
 use Alley\WP\WP_Curate\Tests\Test_Case;
+use simplehtmldom\HtmlDocument;
 
 /**
  * A test suite for unique pinned posts.
@@ -112,9 +113,9 @@ class UniquePinnedPostTest extends Test_Case {
 			)
 			->create_and_get( [ 'post_content' => $content ] );
 
-		$page = $this->get( $test_post )->assertOk();
-
-		$this->assertEquals( 2, substr_count( $page->get_content(), 'Pinned Post 1' ) );
+		$page       = $this->get( $test_post )->assertOk();
+		$wp_content = $this->extract_wp_content( $page->get_content() );
+		$this->assertEquals( 2, substr_count( $wp_content, 'Pinned Post 1' ) );
 	}
 
 	/**
@@ -142,7 +143,26 @@ class UniquePinnedPostTest extends Test_Case {
 			->create_and_get( [ 'post_content' => $content ] );
 
 		$page = $this->get( $test_post )->assertOk();
+		$wp_content = $this->extract_wp_content( $page->get_content() );
+		$this->assertEquals( 1, substr_count( $wp_content, 'Pinned Post 2' ) );
+	}
 
-		$this->assertEquals( 1, substr_count( $page->get_content(), 'Pinned Post 2' ) );
+	/**
+	 * Gets the contents of the .entry-content div.
+	 *
+	 * @param string $html_content The content of the page.
+	 * @return string
+	 */
+	function extract_wp_content( $html_content ) {
+		$html = new HtmlDocument();
+		$html->load( $html_content );
+
+		$div = $html->find( 'div.entry-content', 0 );
+
+		if ( $div ) {
+			return $div->innertext;
+		}
+
+		return '';
 	}
 }

--- a/tests/feature/UniquePinnedPostTest.php
+++ b/tests/feature/UniquePinnedPostTest.php
@@ -142,7 +142,7 @@ class UniquePinnedPostTest extends Test_Case {
 			)
 			->create_and_get( [ 'post_content' => $content ] );
 
-		$page = $this->get( $test_post )->assertOk();
+		$page       = $this->get( $test_post )->assertOk();
 		$wp_content = $this->extract_wp_content( $page->get_content() );
 		$this->assertEquals( 1, substr_count( $wp_content, 'Pinned Post 2' ) );
 	}
@@ -153,7 +153,7 @@ class UniquePinnedPostTest extends Test_Case {
 	 * @param string $html_content The content of the page.
 	 * @return string
 	 */
-	function extract_wp_content( $html_content ) {
+	private function extract_wp_content( $html_content ) {
 		$html = new HtmlDocument();
 		$html->load( $html_content );
 

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,12 +3,12 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.4.2
+ * Version: 2.4.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4
  * Requires PHP: 8.1
- * Tested up to: 6.4
+ * Tested up to: 6.7
  *
  * Text Domain: wp-curate
  *


### PR DESCRIPTION
### Summary
Fixes #236 - Subquery block missing support for custom post titles.

### Description of the bug

Adding a Subquery block does not include a post title in the block title. Initially, setting a custom post title was not available within a Subquery block.

### Steps To Reproduce

1. Create a new Query block.
2. Add a nested Subquery block within the Post Template.
3. Core Post Title block is inserted.

### Solution

Support for custom post titles within Subquery blocks has been added, allowing users to set custom titles for posts within these blocks.

### Additional Information
When hardcoding the Custom Post Title block, it's possible to set a custom title. However, the value is set on the Query block and is used for any duplicate instance of the post within the Query.

Example code for creating Query with Subquery

```
<!-- wp:wp-curate/query {"postTypes":["post"],"posts":[null,null,null,null,null]} -->
<div class="wp-block-wp-curate-query"><!-- wp:post-template -->
<!-- wp:wp-curate/post -->
<div class="wp-block-wp-curate-post"><!-- wp:post-title {"isLink":true} /-->

<!-- wp:wp-curate/subquery {"numberOfPosts":2,"postTypes":[{"name":"Post","slug":"post"}],"posts":[null,null],"terms":{"category":[], "post_tag":[]},"uniqueId":"87552371-c7f9-4175-9105-d5ab61240864"} -->
<div class="wp-block-wp-curate-subquery"><!-- wp:post-template -->
<!-- wp:wp-curate/post -->
<div class="wp-block-wp-curate-post"><!-- wp:post-title {"level":3,"isLink":true} /--></div>
<!-- /wp:wp-curate/post -->
<!-- /wp:post-template --></div>
<!-- /wp:wp-curate/subquery --></div>
<!-- /wp:wp-curate/post -->
<!-- /wp:post-template --></div>
<!-- /wp:wp-curate/query -->
```