### PR TITLE
fix (workaround) block transform preview issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.4.5 - 2024-12-10
+
+- Bug Fix: Prevent block transformation preview issues on WordPress 6.7.
+
 ## 2.4.4 - 2024-12-02
 
 - Restore maxNumberOfPosts attribute with a default filterable value of maxPosts.

--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -92,6 +92,10 @@ export function mainDedupe() {
   if (document.querySelector('.block-editor-block-switcher__popover__preview__parent')) {
     return;
   }
+  // Same, but for WordPress 6.7 and later.
+  if (document.querySelector('.block-editor-block-switcher__popover-preview')) {
+    return;
+  }
 
   running = true;
   // Clear the flag for another run.

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.4.4
+ * Version: 2.4.5
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
add class for WordPress 6.7