### PR TITLE
Issue-278: In the title block, manually setting a custom title back to the original title does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.4.9 - 2025-01-13
+
+- Bug Fix: Allow manually resetting custom post title back to original title.
+
 ## 2.4.8 - 2024-12-17
 
 - Bug Fix: Roll back to React 18 again.

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -92,10 +92,7 @@ export default function Edit({
      * Handle cases for when it's not necessary to update the collection of
      * custom titles
      */
-    if (
-      title === rawTitle
-      || title === currentCustomPostTitle?.title
-    ) {
+    if (title === currentCustomPostTitle?.title) {
       return;
     }
 
@@ -112,6 +109,9 @@ export default function Edit({
           title,
         },
       ];
+    }
+    if (title === rawTitle) {
+      newCustomPostTitles = newCustomPostTitles.filter((item) => item?.postId !== postId);
     }
 
     // @ts-ignore

--- a/blocks/post-title/edit.tsx
+++ b/blocks/post-title/edit.tsx
@@ -110,6 +110,7 @@ export default function Edit({
         },
       ];
     }
+    // If the custom title matches the original title, we don't want to store it.
     if (title === rawTitle) {
       newCustomPostTitles = newCustomPostTitles.filter((item) => item?.postId !== postId);
     }

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.4.8
+ * Version: 2.4.9
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
**Summary:**
This PR addresses the issue where manually setting a custom title back to the original title in the title block does not work as expected. Specifically, if a custom title is set for a pinned post and later attempts are made to revert it back to its original title, the changes do not save correctly. The problem seems to be related to the handling of custom titles in the code. Fixes #278

**Changes:**
- Modify the title handling logic to ensure that setting a title back to its original value is properly saved.
- Implemented a fix allowing users to manually reset the custom post title back to its original.

**Test Plan:**
1. Pin a post.
2. Set a custom post title.
3. Attempt to manually revert the title back to the original title.
4. Save and refresh to confirm that the title has been successfully reverted to its original form.

**Additional Information:**
- Issue link: [Issue #278](https://github.com/alleyinteractive/wp-curate/issues/278)