### PR TITLE
Issue-314: Query block init needs to run at higher priority to pick up custom post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.6.2 - 2025-05-15
+
+- Enhancement: Change priority for query block init to 900, to allow more time for registration of custom post types and taxonomies.
+
 ## 2.6.1 - 2025-04-09
 
 - Bug Fix: Revert update to wp-type-extensions to avoid conflicts with the Alleyvate plugin.

--- a/blocks/query/index.php
+++ b/blocks/query/index.php
@@ -100,7 +100,7 @@ function wp_curate_query_block_init(): void {
 		]
 	);
 }
-add_action( 'init', 'wp_curate_query_block_init' );
+add_action( 'init', 'wp_curate_query_block_init', 900 );
 
 /**
  * Renders the `wp-curate/query` block on the server.

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.6.1
+ * Version: 2.6.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
### Summary

Fixes #314  

This pull request addresses an issue where custom post types registered at `init` priority 10 (or higher) are not being picked up by the query block. The initialization priority for the query block has been adjusted to ensure all post types and taxonomies are registered before being referenced. Additionally, the plugin version has been updated to `2.6.2` to reflect this enhancement.

### Description

The issue arises because the query block's initialization currently runs at a priority that may precede the registration of custom post types, particularly when those post types are registered at a higher priority (e.g., 10 or above). This results in custom post types not appearing as options in the query block.

The fix involves increasing the initialization priority of the query block to `900`, ensuring that all post types and taxonomies are registered before being referenced by the block. This update will also be included in version `2.6.2` of the `WP Curate` plugin as part of its changelog.

### Steps To Reproduce

1. Add custom post types at `init` priority 10 (or higher).
2. Add the post types to the allowed post types list by filtering `wp_curate_allowed_post_types`.
3. View a query block. You will not see the custom post types as options.

### Additional Information

This issue is particularly relevant for post types generated by [Mantle models](https://mantle.alley.com/docs/models/model-registration). The fix ensures compatibility with such models and other cases where post types are registered at later priorities. 

The plugin's version has been updated from `2.6.1` to `2.6.2` to reflect this change, and the changelog has been updated accordingly.

### Testing Instructions

1. Register a custom post type at `init` priority 10 (or higher).
2. Add the custom post type to the allowed post types list using the `wp_curate_allowed_post_types` filter.
3. Verify that the custom post type appears as an option in the query block after applying this fix.