### PR TITLE
Issue-318: Subquery block should include a parent

### DIFF
--- a/blocks/subquery/block.json
+++ b/blocks/subquery/block.json
@@ -17,6 +17,9 @@
         "query",
         "postId"
     ],
+    "parent": [
+      "wp-curate/query"
+    ],
     "providesContext": {
         "query": "query",
         "pinnedPosts": "posts",


### PR DESCRIPTION
## Summary

Fixes #318

This pull request addresses an issue where the Subquery block could previously be inserted anywhere within the editor, leading to unintended usage. With this update, the Subquery block is now restricted to only be inserted within a Query block. This is achieved by adding a `parent` property to the Subquery block's registration configuration, specifically allowing it only as a child of the `wp-curate/query` block. This change improves block structure and enforces intended usage patterns.

## How Has This Been Tested?

- Attempted to insert a Subquery block outside of a Query block and confirmed that it is not permitted.
- Inserted a Subquery block within a Query block and verified it works as expected.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (if appropriate)

N/A

## Additional Notes

N/A