### PR TITLE
Issue-334: Custom Taxonomy REST Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.6.3 - 2025-07-17
+
+- Bug Fix: Require Subquery block to have a parent Query block to prevent errors when used outside of a Query block.
+- Bug Fix: Handle custom taxonomies that do not have a `rest_base` set.
+- Enhancement: Display `No results found.` messages when not posts are found in the Query block.
+
 ## 2.6.2 - 2025-05-15
 
 - Enhancement: Change priority for query block init to 900, to allow more time for registration of custom post types and taxonomies.

--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -10,6 +10,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { Template } from '@wordpress/blocks';
 import type { WP_REST_API_Posts as WpRestApiPosts } from 'wp-types'; // eslint-disable-line camelcase
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 
 import type {
   EditProps,
@@ -249,7 +250,11 @@ export default function Edit({
         ),
       })}
       >
-        <InnerBlocks template={TEMPLATE} />
+        {
+          error ? (
+            <p>{__('No results found.', 'wp-curate')}</p>
+          ) : <InnerBlocks template={TEMPLATE} />
+        }
       </div>
       <QueryControls
         allowedPostTypes={allowedPostTypes}

--- a/services/buildTermQueryArgs/index.ts
+++ b/services/buildTermQueryArgs/index.ts
@@ -23,7 +23,7 @@ export default function buildTermQueryArgs(
   const termQueryArgs: string[] = [];
   allowedTaxonomies.forEach((taxonomy) => {
     if (terms[taxonomy.slug]?.length > 0) {
-      const restBase = taxonomy.rest_base;
+      const restBase = taxonomy.rest_base || taxonomy.slug;
       if (restBase) {
         termQueryArgs.push(`${restBase}[terms]=${terms[taxonomy.slug].map((term) => term.id).join(',')}`);
         if (termRelations[taxonomy.slug] !== '' && typeof termRelations[taxonomy.slug] !== 'undefined') {

--- a/services/queryBlockPostFetcher/index.ts
+++ b/services/queryBlockPostFetcher/index.ts
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 
 type FetcherProps = [string | undefined, number];
 type PostResponse = number[] | { id: number };
@@ -21,6 +22,14 @@ const queryBlockPostFetcher = (
       revisedResponse = null;
     } else {
       revisedResponse = response;
+    }
+
+    const isValidResponse = revisedResponse
+      && Array.isArray(revisedResponse)
+      && revisedResponse.length > 0;
+
+    if (!isValidResponse) {
+      throw new Error(__('No posts found', 'wp-curate'));
     }
     return revisedResponse;
   });

--- a/src/features/class-rest-api.php
+++ b/src/features/class-rest-api.php
@@ -79,7 +79,7 @@ final class Rest_Api implements Feature {
 		$taxonomies         = array_filter( $taxonomies, 'is_object' );
 		$tax_query          = [];
 		foreach ( $taxonomies as $taxonomy ) {
-			$rest_base = $taxonomy->rest_base;
+			$rest_base = $taxonomy->rest_base ?: $taxonomy->name;
 			if ( empty( $rest_base ) || ! is_string( $rest_base ) ) {
 				continue;
 			}

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.6.2
+ * Version: 2.6.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
## Summary
If a `rest_base` is not defined for a custom taxonomy, the Query component can sit in a state of loading. If not `rest_base` has been defined, we've added in functionality to fall back to the slug / name. 

Also, add in messaging that no results were found instead of a constant loading state.

## Testing
- Register a custom taxonomy but don't define a rest base
- Verify the Query block can be filtered by that custom taxonomy after it has been allowed
- Remove all posts from the custom taxonomy and filter by it to see the `No results found.` text.

## Ticket
Fixes #334 