### PR TITLE
FAM: Bump alleyinteractive/wp-type-extensions to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": "^8.2",
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/traverse-reshape": "^2.0",
-    "alleyinteractive/wp-type-extensions": "^3.0"
+    "alleyinteractive/wp-type-extensions": "^3.0|^4.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",


### PR DESCRIPTION
As titled.