### PR TITLE
Issue #326 - Block Styles Applied to Editor Only

### DIFF
--- a/blocks/query/index.scss
+++ b/blocks/query/index.scss
@@ -2,6 +2,11 @@
  * Editor styles for the wp-curate/query block.
  */
 
+.wp-block-wp-curate-query {
+  min-height: 50px;
+  padding: 2px;
+}
+
 .autocomplete__component .components-base-control__label {
   display: inline-block;
   font-size: 11px;
@@ -37,7 +42,7 @@
 
 .manual-posts__counter {
   font-weight: 500;
-  
+
   // Give counters a min-width if there are double digits.
   .manual-posts:has(.manual-posts__container:nth-last-child(10)) & {
     min-width: 18px;

--- a/blocks/query/style.scss
+++ b/blocks/query/style.scss
@@ -2,8 +2,3 @@
  * Styles for the wp-curate/query block that get applied on both on the front of your site
  * and in the editor.
  */
-
-.wp-block-wp-curate-query {
-  min-height: 50px;
-  padding: 2px;
-}

--- a/blocks/subquery/index.scss
+++ b/blocks/subquery/index.scss
@@ -5,6 +5,7 @@
 .wp-block-wp-curate-subquery {
   border: 1px dotted #ccc;
   opacity: 1;
+  padding: 2px;
 
   p.zero-posts {
     font-size: 0.8em;

--- a/blocks/subquery/style.scss
+++ b/blocks/subquery/style.scss
@@ -2,7 +2,3 @@
  * Styles for the wp-curate/subquery block that get applied on both on the front of your site
  * and in the editor.
  */
-
-.wp-block-wp-curate-subquery {
-  padding: 2px;
-}


### PR DESCRIPTION
This PR resolves [issue #326](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

**Summary of changes:**

- Moved min-height: 50px and padding: 2px for .wp-block-wp-curate-query from [style.scss](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (front-end + editor) to [index.scss](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (editor only).
- Moved padding: 2px for .wp-block-wp-curate-subquery from [style.scss](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (front-end + editor) to [index.scss](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (editor only).
- Ensured no unwanted block spacing or minimum height is applied on the front-end, improving theme compatibility and reducing the need for CSS overrides.



**Testing:**

- Add Query and Subquery blocks in the editor and confirm spacing/min-height is present.
- View the blocks on the front-end and confirm no extra spacing/min-height is applied.