### PR TITLE
Issue-378: Add option to \"Pin this Post\" in addition to \"Pin a Post\"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `WP Curate` will be documented in this file.
 
+## 2.7.1 - 2025-10-01
+
+- Enhancement: Add option to "Pin This Post" so editors can pin the selected post.
+
 ## 2.7.0 - 2025-09-05
 
 - Enhancement: Update wp-type-extensions to 4.0.0.

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -207,6 +207,22 @@ export default function Edit({
             resetText={__('Backfill post', 'wp-curate')}
             replaceText={__('Pin a different post', 'wp-curate')}
           />
+          {
+            // If this post isn't already in the posts list, show a button to pin it.
+            !posts.includes(postId) && !postDeleted
+              ? (
+                <Button
+                  className="wp-curate-post-block__pin-post"
+                  variant="secondary"
+                  onClick={() => {
+                    updatePost(postId);
+                  }}
+                >
+                  {__('Pin this post', 'wp-curate')}
+                </Button>
+              )
+              : null
+          }
         </div>
       ) : null}
     </div>

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -203,9 +203,9 @@ export default function Edit({
             value={selected ?? 0}
             previewRender={(NoRender)}
             className="wp-curate-post-block__post-picker"
-            selectText={__('Pin a post', 'wp-curate')}
-            resetText={__('Backfill post', 'wp-curate')}
-            replaceText={__('Pin a different post', 'wp-curate')}
+            selectText={__('Pin a Post', 'wp-curate')}
+            resetText={__('Backfill Post', 'wp-curate')}
+            replaceText={__('Pin a Different Post', 'wp-curate')}
           />
           {
             // If this post isn't already in the posts list, show a button to pin it.
@@ -218,7 +218,7 @@ export default function Edit({
                     updatePost(postId);
                   }}
                 >
-                  {__('Pin this post', 'wp-curate')}
+                  {__('Pin This Post', 'wp-curate')}
                 </Button>
               )
               : null

--- a/blocks/post/index.scss
+++ b/blocks/post/index.scss
@@ -13,14 +13,11 @@
   }
 
   &__actions {
-    align-items: center;
+    align-items: flex-end;
     display: flex;
-    justify-content: space-between;
+    gap: 0.5rem;
+    justify-content: flex-end;
     margin-top: 0.5rem;
-
-    &__post-picker {
-      align-self: flex-end;
-    }
   }
 }
 
@@ -67,10 +64,10 @@
   .wp-curate-post-block__actions, .components-button-group {
     display: flex;
     flex-direction: column;
+    gap: 0.5rem;
     width: 100%;
 
     button {
-      margin: 0 0 0.25rem 0 !important;
       text-align: left;
       width: 100%;
     }

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 2.7.0
+ * Version: 2.7.1
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
### Summary

Fixes #378

### Description

Adds the option to "Pin this Post" as a shortcut to pinning a backfilled post directly from the editor, eliminating the need to search for the post in the PostPicker when it is already displayed.

### Use Case

When a user sees the post they want to pin in the backfill, it's easier to "Pin this Post" instead of searching for it in the PostPicker.

### Testing Instructions

- Ensure that the "Pin this Post" option appears for backfilled posts displayed in the editor.
- Verify that selecting "Pin this Post" successfully pins the post without needing to use the PostPicker.
- Check that existing "Pin a Post" functionality is unaffected.

### Screenshots (if applicable)

<!-- Add screenshots here if relevant -->

### Additional Notes

<!-- Add any additional implementation notes, caveats, or related information here -->
