### PR TITLE
Adds notice compoment and updates language for error messsage

### DIFF
--- a/blocks/query/edit.tsx
+++ b/blocks/query/edit.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from '@uidotdev/usehooks';
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
+import { Notice } from '@wordpress/components';
 
 import { Template } from '@wordpress/blocks';
 import type { WP_REST_API_Posts as WpRestApiPosts } from 'wp-types'; // eslint-disable-line camelcase
@@ -259,7 +260,12 @@ export default function Edit({
       >
         {
           error ? (
-            <p>{__('No results found.', 'wp-curate')}</p>
+            <Notice
+              status="warning"
+              isDismissible={false}
+            >
+              {__('WP Curate Query - No posts matching criteria found.', 'wp-curate')}
+            </Notice>
           ) : <InnerBlocks template={TEMPLATE} />
         }
       </div>


### PR DESCRIPTION
This PR cleans up the error/warning triggered when the Query block returns no posts:

- The message was displayed in an unstyled paragraph tag so I replaced that with the core `Notice` component which looks a lot cleaner.
- Updated the language of the error message to be a bit clearer and more specific.