### PR TITLE
Issue-356: Downgrade React-DOM to Version 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6330,6 +6330,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.2.tgz",
       "integrity": "sha512-naxcJgUJ6BTOROJ7C3QML7KvwKwCXQJYTc5L/b0eEsdYgPB6SxwoQ1vDGcS0Q7GVjAenVq/tXrybVdFShHYZWg==",
+      "license": "MIT",
       "dependencies": {
         "@preact/signals-core": "^1.7.0"
       },
@@ -6345,6 +6346,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
       "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6402,12 +6404,14 @@
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -6422,6 +6426,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -6436,6 +6441,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
       "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -6471,6 +6477,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
       "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -6497,6 +6504,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
       "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -6511,6 +6519,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
       "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
@@ -6535,6 +6544,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
       "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
@@ -6552,6 +6562,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
       "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -6575,6 +6586,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
       "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -6598,6 +6610,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
       },
@@ -6620,6 +6633,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
@@ -6637,6 +6651,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -6651,6 +6666,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-effect-event": "0.0.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -6669,6 +6685,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
       "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
@@ -6686,6 +6703,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
@@ -6703,6 +6721,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7949,9 +7968,10 @@
       "license": "MIT"
     },
     "node_modules/@types/simple-peer": {
-      "version": "9.11.8",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.8.tgz",
-      "integrity": "sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==",
+      "version": "9.11.9",
+      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.9.tgz",
+      "integrity": "sha512-6Gdl7TSS5oh9nuwKD4Pl8cSmaxWycYeZz9HLnJBNvIwWjZuGVsmHe9RwW3+9RxfhC1aIR9Z83DvaJoMw6rhkbg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -9998,82 +10018,63 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.31.0.tgz",
-      "integrity": "sha512-LU2Ea+RRaqe1Q8u15Y1dBxXfGwPsOtqXLZR7Bfk7y9yMsJnKqymovR7yvoPYe/4dWXy0B9sK1jUJtPAMUFfOng==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.33.0.tgz",
+      "integrity": "sha512-LUFmuDkwKS15XkV8ziR2isSMvgLZjyRg0EQD4lfCywS9ycQzuzGFHDzUxpg0ECjYQfRrGDzMcPQe5ts8HuklOA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/dom-ready": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/dom-ready": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/a11y/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/admin-ui": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-1.1.0.tgz",
+      "integrity": "sha512-YhzlNXI8DT8u8N2idtE5mWwmnVvJAKZqw4QaGFT/TO5LLrPFEmfYFqhFMTwnYUFfocgjW2qP0FI1OtDw6KFjjQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/element": "^6.33.0",
+        "clsx": "^2.1.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.31.0.tgz",
-      "integrity": "sha512-mEnNA2QvLeopNfXhRYaaCyF6Db1zZUaQI/+3UIJCn66OasoNQnvPHyHxWCRegsDfdtL7tCyvSuAbB++9wzcDyQ==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+      "integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/url": "^4.31.0"
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/url": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/api-fetch/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.31.0.tgz",
-      "integrity": "sha512-PzmFe0gePKxdld01Nk/9quklzEZCshyCncs2uVaAzCXQ8jvubQo7Z9QYXHjY8ukHXCG+RyaYuj+PJrimV6iX2A==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.33.0.tgz",
+      "integrity": "sha512-F7639N+pjPQDATwKVRSgZPOvdfeunbAO/wOKvDrQ8DAObgAcbFwz1iTtNw9chiB8/r7/x31TzPU1QxHbjn9xeA==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/autop/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.33.0.tgz",
-      "integrity": "sha512-zi+TfLm7w8UmC/IE1b6/z+GIRMvv9s6yQ7+2a3XUEFriAiLwVM2cRXTcauaKkcos3BDi35M0V8x0T7980RwTlQ==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.33.1.tgz",
+      "integrity": "sha512-nB/vm8bNgrJbMyX5YaCafeXjKs1LVVde886bVWf9lnIhlDhkAqF9qZN2Hd5B6h1JbQJp7Kc0bFSROXDcS/JZpw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -10083,8 +10084,8 @@
         "@babel/plugin-transform-runtime": "7.25.7",
         "@babel/preset-env": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
-        "@wordpress/browserslist-config": "^6.33.0",
-        "@wordpress/warning": "^3.33.0",
+        "@wordpress/browserslist-config": "^6.33.1",
+        "@wordpress/warning": "^3.33.1",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.0"
@@ -10257,9 +10258,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.0.tgz",
-      "integrity": "sha512-z3WCO0EdVWrXkEn6QXlFQZoKyPxplIctOWTqG8KPLtdHa0gqXhF+gaNxwGg6Ao2ac4sqoFSBcKPhXgE/08jK7g==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.1.tgz",
+      "integrity": "sha512-UCtTANAdym5jpTEZS17WHrKLu7R52gQRgKuwsRm5uZWUb4g4Vq8NX52CBIesF1viFyKfM++HpmteFkrL7p0SMg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10267,69 +10268,57 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.31.0.tgz",
-      "integrity": "sha512-14QzAp4tTFowxMgNjz2refH6ziGTX4TBfpDyTs+/grNzOhRlOlUOSx7u2S7zZekWzp/A6nsGklGr3ACrpkrDXA==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.33.0.tgz",
+      "integrity": "sha512-ZgrzNRsSyi5tpOBhHlmjd4131PTKH7E+1z9BF3eeyo+3nQAvkTU1hdHQ7yJpbF/7Ss1FeTjF+qvKoB25p9c1/w==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/blob/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.4.0.tgz",
-      "integrity": "sha512-vBnxrrT4UJ+gum5Z8oS3s8ULqjKlXrkHOrwQEVjc+8+wTwp1qePzCttA08eVqAFsO9JzeseIhiJkUAEhezFwIQ==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.6.0.tgz",
+      "integrity": "sha512-Y+BXztP8RBaACBSrYG3aXuuLA+w46B1azLK5qluZms7TyBG7nyS7n0WDLeTIejfNvzJjy3lwKJ9nJSETjrBUfg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-serialization-default-parser": "^5.31.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/commands": "^1.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/priority-queue": "^3.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/style-engine": "^2.31.0",
-        "@wordpress/token-list": "^3.31.0",
-        "@wordpress/upload-media": "^0.16.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
-        "@wordpress/wordcount": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-serialization-default-parser": "^5.33.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/commands": "^1.33.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/priority-queue": "^3.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/style-engine": "^2.33.0",
+        "@wordpress/token-list": "^3.33.0",
+        "@wordpress/upload-media": "^0.18.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
+        "@wordpress/wordcount": "^4.33.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -10354,23 +10343,24 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/escape-html": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+      "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/escape-html": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-      "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10378,12 +10368,12 @@
       }
     },
     "node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10391,44 +10381,46 @@
       }
     },
     "node_modules/@wordpress/block-library": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.31.0.tgz",
-      "integrity": "sha512-BlqpLwn4zyUauwrkOO2agHD9Xo93jZcdapqk0IzvbYR9BoJJIZjj3JKp8huc5diVS79KkS590rqs7Yk6sZJWNg==",
+      "version": "9.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.33.1.tgz",
+      "integrity": "sha512-SQ5jW0OJwEy4LIL16V5SK39wWgyKt4A8y1Ye070nwcZmamTIvg1wqypITtwqXfJVAX9YUZvicX3Vb3KOZ6nAfQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/autop": "^4.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/interactivity": "^6.31.0",
-        "@wordpress/interactivity-router": "^2.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/patterns": "^2.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/reusable-blocks": "^5.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/server-side-render": "^6.7.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/viewport": "^6.31.0",
-        "@wordpress/wordcount": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/autop": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/interactivity": "^6.33.0",
+        "@wordpress/interactivity-router": "^2.33.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/latex-to-mathml": "^1.1.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/patterns": "^2.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/reusable-blocks": "^5.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/server-side-render": "^6.9.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/viewport": "^6.33.0",
+        "@wordpress/wordcount": "^4.33.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -10448,23 +10440,24 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/escape-html": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+      "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/@wordpress/escape-html": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-      "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10472,12 +10465,12 @@
       }
     },
     "node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10492,54 +10485,42 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.31.0.tgz",
-      "integrity": "sha512-38pHFz1ugJtYuuSxK7AxFzkmuZbUpSrylNrhjmWv12e0z5aYDNs8jtiii4CPeWD3RPvXEuYpwsOHR/4hTyuFMQ==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.33.0.tgz",
+      "integrity": "sha512-kVtx1zX9/vOWvxU3U1d9jTrjkrB9Z2r2qnkEl8p5E3nSiUrPIvLxPnzPa9KRuRma9uNVH//YUc59kgVxRSALIQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/block-serialization-default-parser/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/blocks": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.4.0.tgz",
-      "integrity": "sha512-hY/oofLfM0zujjQ9vvL7M9hzrW9xTc+MqHvwtAa0jZwCUWVKRY+jGUKp7HpZNcYtF+szR4LXATqS+kqcUAlARg==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.6.0.tgz",
+      "integrity": "sha512-w3O88J9xZ4b+ATCqEnc2RTc+euAtsuAcwHchopLn4MAZcynG/AU7h9HZ6nE6EMPJX1Dv34GJZvQxxMUM4K16zA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/autop": "^4.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-serialization-default-parser": "^5.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/shortcode": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/autop": "^4.33.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-serialization-default-parser": "^5.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/shortcode": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -10560,17 +10541,6 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/blocks/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/blocks/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -10589,9 +10559,9 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.33.0.tgz",
-      "integrity": "sha512-4plw8mLKjcd1beuJzmjT4GNBk+R02qu/og6h/BuGMY8dxfqovfGB0Z2w7C85ILmjY2qnvsU7gelDcSXNgwuwxQ==",
+      "version": "6.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.33.1.tgz",
+      "integrity": "sha512-JVqhw9fK79eztAGRbZd2Cr0JX39vv8a/4Y7oE0iQFst105tyOJP3koMeKZa7x4EJWnbUPNrFFVmwpt/JcaPENw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -10600,18 +10570,19 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.31.0.tgz",
-      "integrity": "sha512-PaBQVIHNGBn2sMxPj5ILJPAe4h79MvUcb5DzgiXA+H+0nNHLsQxg2u8Cfm2spct37dqOLMnQ6PVMRS+SwCLESQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.33.0.tgz",
+      "integrity": "sha512-EJM2QdC0xQp6lVaCybbCQhkaX7/it5cEvYXvLtSSRMbCreu8OhCBvd2IruT8+5QIgnAgBHQkc589SsdW3DNsaA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -10624,24 +10595,27 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/commands/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/components": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.4.0.tgz",
-      "integrity": "sha512-PrZ8+VMCciVkWna//AH55Xg+TALw/E67358B5w/qiBohZ0CaoL1z4UcltkO+Gd5BJ1E14HbD8vC/6ao8dMXEJg==",
+      "version": "30.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.6.0.tgz",
+      "integrity": "sha512-RkY+DIW+iy1Y5jiVYxfs9mNY+noV9AwPlKySJRsVy5o9u7k52HayuNe9cMl5/UsXLNgWHLMUykEZGkgHgNeaRA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "7.25.7",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
@@ -10652,23 +10626,24 @@
         "@types/gradient-parser": "1.1.0",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -10696,23 +10671,24 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/components/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+    "node_modules/@wordpress/components/node_modules/@wordpress/escape-html": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+      "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/components/node_modules/@wordpress/escape-html": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-      "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+    "node_modules/@wordpress/components/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10720,12 +10696,12 @@
       }
     },
     "node_modules/@wordpress/components/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10745,19 +10721,19 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.31.0.tgz",
-      "integrity": "sha512-kxb1qHhiFwUDifBM9r4JZ3gYC1ZUvck5tgjmaWeg8EqIEnVn+Z7C+ntNA9ySLWrmDYc4Gki7YJZbfVHzrtcDLg==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.33.0.tgz",
+      "integrity": "sha512-ICBdgush3DXFWN7VMxTy/3LCK+qpyGMnNhX+XIl3LVug5yOfT77G9JA3Mbpw2cwpihyDdekItlsE0f4rYL/nnA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/priority-queue": "^3.31.0",
-        "@wordpress/undo-manager": "^1.31.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/priority-queue": "^3.33.0",
+        "@wordpress/undo-manager": "^1.33.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -10771,24 +10747,13 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/compose/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/compose/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10796,27 +10761,27 @@
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.31.0.tgz",
-      "integrity": "sha512-Rp/LcmTwBL8uITYmj2HRV6GGT1MKvRvaU594fq+CTZa9kNYDUwhnG7xtC9+JbjPSdZ9zLtHVQUdKbwRvpkcibw==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.33.0.tgz",
+      "integrity": "sha512-Lwde8zJHPvWD6DJFjwM9uYXS0ZvyuG23QVOARYcrWezytQdnXIBRQ70oVa5xfGfd0OSKrIoWBhjWHzJLP+DJRA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/sync": "^1.31.0",
-        "@wordpress/undo-manager": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/sync": "^1.33.0",
+        "@wordpress/undo-manager": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -10832,17 +10797,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/core-data/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/core-data/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -10856,18 +10810,18 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.31.0.tgz",
-      "integrity": "sha512-iuQxrmbW55q+xy7lnXH8D6qHFAoG0/YcnjZ6jvqpDekRhdgl4kAPE+crx/kJ5RkrIIo38a+cLgVskCaKo+9E3w==",
+      "version": "10.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.33.0.tgz",
+      "integrity": "sha512-05USk5y+UoGBW5xEVLWLUJOZsMTMmFRagsdgijV+RETzRj1qTw0Vj3y/mhH49EQ16s7fkPMmcCbZnSiGvATD7g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/priority-queue": "^3.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/redux-routine": "^5.31.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/priority-queue": "^3.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/redux-routine": "^5.33.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -10884,42 +10838,31 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/data/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/data/node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-9.0.0.tgz",
-      "integrity": "sha512-epjNwINFMsql3FG8bhBVkQlPeUzUTgTvkLYrGzmCwM18nLu4L17bbvfhRMG/Nx+49SO+hd8bN2Rcgj3RG7eATg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-10.1.0.tgz",
+      "integrity": "sha512-RYjPsO56xayphKgGLWa1KDrDDx9YFlRlwcJH2EVppFzsu657wK8z7FfLF0lwDsRdnhPQ2sW+db6LmQrnfmK3yQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "7.25.7",
-        "@wordpress/base-styles": "^6.7.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
         "date-fns": "^4.1.0",
@@ -10936,24 +10879,27 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/dataviews/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/dataviews/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10964,18 +10910,19 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.31.0.tgz",
-      "integrity": "sha512-xqKytkb60N9i+ETqTI+Asgb1myZIgnUne8zsGaYQU+B7H1M3ELw4lmc+ptDXjXrpI1Yb6BGUad4EIHBGVk+mog==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.33.0.tgz",
+      "integrity": "sha512-pcZjaytspcLLQIN2cnrK51Zgv4lm/s1qLu/tLEmNg9DeVL3mKsWNBE6JFSmSJzPLQUHtH7k174RwY8g1bBDTbA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.31.0",
+        "@wordpress/deprecated": "^4.33.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -10984,21 +10931,10 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/date/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.33.0.tgz",
-      "integrity": "sha512-uGvJrak1wpi6XAfIvSXedXgfxvavpzVlj7ypAedAqQ26eFLHCPzK9S2TRp+jw4BglUE3mR2NXD8/glorbGwq+g==",
+      "version": "6.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.33.1.tgz",
+      "integrity": "sha512-JyTopRN6TrXOjcu5VVLhpED0tkuMyY1jIMy6oRfPmxPFP52/ulVmBFiaqYtigGuOSsXlbW4SJsU637GOgCUZUw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -11020,36 +10956,25 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.31.0.tgz",
-      "integrity": "sha512-bbDrL2lp7crFfvmJ1EYVxPDcheTIwimt3gVzqQWCDr0SSCQw4fii5NEKOrUnWhz51YCuPbfWXUBaFlbAMS2CXw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.33.0.tgz",
+      "integrity": "sha512-+9RD5oAAH+HGh6YwRJui0mj/WOfxSZi1/0l2YdgKuQsY2DhnJbEscc/86IxSR44IEMItKjIoJO3k9CdeyFyRig==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.31.0"
+        "@wordpress/hooks": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/deprecated/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/dom": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.31.0.tgz",
-      "integrity": "sha512-5/RBy9OreQktnBE75cB3R6Lva5c6hUlXvPo1NFfAebLeXX+7swZBmLYZnyf7dZbARRdqSwkundHZoKLcHa+20A==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.33.0.tgz",
+      "integrity": "sha512-lXF9NiBkiw1uFdUdAmQBxnnIUsFZxxJM2tLTXpRrPBWtB77e1rdmz0xVWBYDHr8FaaOXQ/30TuvhAiNPsbISfg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.31.0"
+        "@wordpress/deprecated": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11057,43 +10982,19 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.31.0.tgz",
-      "integrity": "sha512-aRM4l5wzkrqAU686s4fz1bb+/7/BOFp+sXB0kx1vkiXl3ocfmHAr3jwEYU+OH/sX6Is3Ntkfh0uZe3EJLsqHTQ==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.33.0.tgz",
+      "integrity": "sha512-NDmtk+n0ZoWW0KzPHNSGYfKB/NM2EVxP2HwkBE8tN3+G7Z/hktdcpFiRTPhYoDg2KIAZMngBOzckgGtcIJ3z3A==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/dom-ready/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@wordpress/dom/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.33.0.tgz",
-      "integrity": "sha512-OuxF/5TeHh2k58jsKRG2AtFhoRgAFKUrOjcrBLaNew3Y6RepwvLLgSq1LXqUrR1nhJU90AaH6AqFrJ2s+lmFUw==",
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.33.1.tgz",
+      "integrity": "sha512-ra3JHLuTHJviE50JVMmKViK2qS53sMNhUuG2+vY9zVI69BzEbzajLW/4BnUB0c1HF16h0PW4oZL9m9V4Pi6KXA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -11113,39 +11014,41 @@
       }
     },
     "node_modules/@wordpress/edit-post": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.31.0.tgz",
-      "integrity": "sha512-hPNmXDaVMfVk2BM070xpYUuTKZFm4cr7NcQLcbWc1TjXHx1HOWpB/rjdUUTaDsEn1Ox3+yH5qh4O+309el3NYw==",
+      "version": "8.33.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.33.2.tgz",
+      "integrity": "sha512-/uI8ONhsZd0CYoyi5/p9Imss3eOfRYN6AoMMjXMN8m3usGWkWxYYQFT34p792Rz2rosBlof90YINLFfXX6U+EQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/block-library": "^9.31.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/commands": "^1.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/editor": "^14.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/plugins": "^7.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/viewport": "^6.31.0",
-        "@wordpress/warning": "^3.31.0",
-        "@wordpress/widgets": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/admin-ui": "^1.1.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/block-library": "^9.33.1",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/commands": "^1.33.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/editor": "^14.33.2",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/plugins": "^7.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/viewport": "^6.33.0",
+        "@wordpress/warning": "^3.33.0",
+        "@wordpress/widgets": "^4.33.0",
         "clsx": "^2.1.1",
         "memize": "^2.1.0"
       },
@@ -11158,24 +11061,27 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/edit-post/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11183,46 +11089,48 @@
       }
     },
     "node_modules/@wordpress/editor": {
-      "version": "14.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.31.0.tgz",
-      "integrity": "sha512-J5D0EmTMuw0YUer0t8fgC1n/Avuu+TbCtfJoQLgCcI4Bi6ZwjiKpoooBDBpKCVqCV+Xut3R9thLaSJcyDVpTrA==",
+      "version": "14.33.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.33.2.tgz",
+      "integrity": "sha512-B49leSFoH6W6pSDHMtn74JBBVVeukdungut9hI6fnEscELiBUmQPAe5Gxnr1S9PDbTYVa6sLdNZoJNXXzFlcHA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/commands": "^1.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/dataviews": "^9.0.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/fields": "^0.23.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/interface": "^9.16.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/media-utils": "^5.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/patterns": "^2.31.0",
-        "@wordpress/plugins": "^7.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/reusable-blocks": "^5.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/server-side-render": "^6.7.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
-        "@wordpress/wordcount": "^4.31.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/commands": "^1.33.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/dataviews": "^10.1.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/fields": "^0.25.2",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/interface": "^9.18.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/media-utils": "^5.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/patterns": "^2.33.0",
+        "@wordpress/plugins": "^7.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/reusable-blocks": "^5.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/server-side-render": "^6.9.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
+        "@wordpress/wordcount": "^4.33.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
@@ -11244,24 +11152,27 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/editor/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/editor/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11276,19 +11187,20 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.31.0.tgz",
-      "integrity": "sha512-KOier6Y4b4Y5yEV1GYen81R9gCEOvJT6eVbsc93w2fFEKi2FK/oI7IKzGv9GeJMkoCWvTSX6C/ZYTWk6fCUfeA==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.33.0.tgz",
+      "integrity": "sha512-vUcH12viRpHkqZ1j3kEqE3bnCvl0tsvUUgp9USgeqRx9YE+8XAn6MdghvwF65/R2It66vqogJlKnbO4wfXehTA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.31.0",
+        "@wordpress/escape-html": "^3.33.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -11299,24 +11211,11 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/element/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/element/node_modules/@wordpress/escape-html": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-      "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+      "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -11354,17 +11253,17 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "22.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.19.0.tgz",
-      "integrity": "sha512-J24RZ6U4Ref0ix8uhmc3XJGkJLdi/V+JOQjjRwB0uLpsSHio4+LhAJrBlovkZCf+0HsRKiJHuIdli0EKW5gl3g==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.19.1.tgz",
+      "integrity": "sha512-7rMkG4nk+nVLaRJxbR4/XYlTPHJT/3IeMyK9eZpKFJgBvL/NQbOC1Oq0n8VZHp1U/Q8csAl/uABJZ9EKLeDMnA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "7.25.7",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^8.33.0",
-        "@wordpress/prettier-config": "^4.33.0",
+        "@wordpress/babel-preset-default": "^8.33.1",
+        "@wordpress/prettier-config": "^4.33.1",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -11415,34 +11314,35 @@
       }
     },
     "node_modules/@wordpress/fields": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.23.0.tgz",
-      "integrity": "sha512-Nc6c8JlITyO9Y1CJKs0KN7YZbGi11ITeJNVT/WCjhgi7HlDk+hDHuJaIZCNxiTICspDiVQKiVBcN/c0CQ1uv1A==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.25.2.tgz",
+      "integrity": "sha512-Z23pnkJ0NTdlubzXAj2Kd4OsBDzfSCXByzPKYDNlw8mm5OlTJYiGgYmk2AMN82NQbmAqhm/VB90rq+ufRbNAyg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/dataviews": "^9.0.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/media-utils": "^5.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/patterns": "^2.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/router": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/dataviews": "^10.1.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/media-utils": "^5.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/patterns": "^2.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/router": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "2.1.1",
@@ -11456,71 +11356,48 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/fields/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/fields/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.31.0.tgz",
-      "integrity": "sha512-8YOftWP54V4hvO46/FgXnpiB/fAC72CWD/F1JYtcfZcrWgbR96MGZxKXNvn5BgLx6juO36QQuFhJ5y2ZUEulkw==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.33.0.tgz",
+      "integrity": "sha512-UwYLO+d3B2a9YtyiKTKjpE+j+eXI1pgySUutD8DL9DnHZMKX/TY4pBdSH4tyNMYxA2Jx0HBDhxBWVkE6e2KB6A==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/hooks/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.31.0.tgz",
-      "integrity": "sha512-5dk9h16jSXDTSdk0HnyXEOgZd7VSsMtr3YCSUQvzIYOFkpW2q1eB10coXHiuz0Z5ArlTuNYSfBd2J02xnG+a8g==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.33.0.tgz",
+      "integrity": "sha512-BidF5J9hvxWe/OUqw/k8+aVnZ8KykUIYYix9V5LpFQIq2Y3pC/W344t/vXY5hRZELz9ojBJVft6bClsIbjCdoQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/html-entities/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/i18n": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.4.0.tgz",
-      "integrity": "sha512-tLTjdLw8H778K4fmEo5NDLYJOAgvHxgfLU5N7lPuBy2TKi8tQl24xgmJOlDLiMzbmbSEwvUBZ/4xWJsGq9ITDQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.6.0.tgz",
+      "integrity": "sha512-tPbvLiOl09M2NBt+pKA2bRUH5GEAzSPHt6cNEF1vbDPSIrtcv/B76x3uRE/hEb6gz67HW594fyAwV7ES/4hZhA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.31.0",
+        "@wordpress/hooks": "^4.33.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -11531,17 +11408,6 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/i18n/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@wordpress/icons": {
@@ -11570,9 +11436,10 @@
       }
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.31.0.tgz",
-      "integrity": "sha512-5qpjRrlvF7sV3r9pUi3Y3fMD07/aeBA8zj4AmMgnRvTAw87580bszwNcUKVChDzVP8Bjpi2QMHGvhY36aXjFpQ==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.33.0.tgz",
+      "integrity": "sha512-KrwM685gGE8t2D4jM1JuQlPySzDx2QFo4cFJhQgDLEgl15fvx+l8Y2uVKO1yx0AxLRHdtuXEqfdQFVMLGEUOYw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
         "preact": "^10.24.2"
@@ -11583,12 +11450,13 @@
       }
     },
     "node_modules/@wordpress/interactivity-router": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.31.0.tgz",
-      "integrity": "sha512-j3KDaT97kQcbW5JH1Nf+SeaoCWEbo8JfNkf+6U8sZl76D5mjx8K+AGQjMnJhgGDXYrutpDl+1XjwqBvA0NDFqg==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.33.0.tgz",
+      "integrity": "sha512-vrmdoV2c0Qmqe9F/1rQUCRkQBeEAvow7pB3H5BZX2pkegbbexp0PIQtBkL1GV4HdNNMyDBnBlpYlbw8vvDOVmg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/interactivity": "^6.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/interactivity": "^6.33.0",
         "es-module-lexer": "^1.5.4"
       },
       "engines": {
@@ -11597,22 +11465,23 @@
       }
     },
     "node_modules/@wordpress/interface": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.16.0.tgz",
-      "integrity": "sha512-VWuYYpYz+J9kN6U1qhE1Te4JKSMEb0OvKSrb9+ErDNLYM5f9yVcPlOXmbwnGcAGYMRxZn7S+kUpBHMqp7jUz2w==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.18.0.tgz",
+      "integrity": "sha512-U89Wsl/6miZXEfurhVF8MLYW80t1yUqORmP22+5NKmx76WJ+66kw1ptANta2dgR+uZr6hWn2Yu/Zwx1GyG/XNA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/plugins": "^7.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/viewport": "^6.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/admin-ui": "^1.1.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/plugins": "^7.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/viewport": "^6.33.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -11624,44 +11493,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/interface/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/interface/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.31.0.tgz",
-      "integrity": "sha512-jqGEw+5DLNf2kNbjaNxIKWQGYkqxygRYDYTdhZ+f+Btw/gMKILJq0sZGRD8YjJFGG0cOC2qxtJnr9oF36Iu96Q==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/is-shallow-equal/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+    "node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.33.0.tgz",
+      "integrity": "sha512-nd8yAVFXnPw4V91MjHQ58eEc/wiDHh4KplUfWzfLd2EesLbRlrtFcZyXe4NkeMlGk+Prfy7wJyNNrax17sBCBQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.33.0.tgz",
-      "integrity": "sha512-G9mJYPpGokk+G5MCM2xMQzHqmZY2DNTFDxtJnmH4ISHm4+2S2OTsHovTNuOM+n8QqaaB2En4uuBfYykpRQfNlw==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.33.1.tgz",
+      "integrity": "sha512-oJaw7Uf3ZICLNhTeHSV6zYnicL1op70YQPPF95fP25wMa9RLiwWlJvbsIp1iZw1VWoIQi6uQXOLfTSkvHvqeEg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -11676,13 +11535,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.33.0.tgz",
-      "integrity": "sha512-TI3FHvMyWeC36IBz7lGaADLIHrSow9Yj80jwisWZ1uppWkAh1wwnJuGnMUn6dSydUolCGitLcMBjA/kGx3uPLw==",
+      "version": "12.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.33.1.tgz",
+      "integrity": "sha512-z5/2wf6ImYx2o3UEEEr+PNQkHul96Jo9U2ncljDHNckV38WJprqJJvHZdL53U9nRs92YgdVn0lR/mfIO/jYpZg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.33.0",
+        "@wordpress/jest-console": "^8.33.1",
         "babel-jest": "29.7.0"
       },
       "engines": {
@@ -11750,14 +11609,14 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.31.0.tgz",
-      "integrity": "sha512-7rEarvwA93+tNC/HPTMK5kuXLBHSSOXgKJz3H2ZPCsYnk6Jf34QeMHOsCJvzA8MuMbx+TBihpEM8JkAkeko60w==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.33.0.tgz",
+      "integrity": "sha512-hFCHRlhPUOlpoXB6R2Wt3QPFJnqN6GutVjMAXnbduWk9m9KCfRiGs/K7N718PtHjX90COrODoumr3/ybHs1iGQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/keycodes": "^4.31.0"
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/keycodes": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11767,24 +11626,13 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11833,42 +11681,44 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/media-utils": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.31.0.tgz",
-      "integrity": "sha512-41O67AO/axvxYbrCp/rgGsYTrSbIWd7b7IC3R7nlSCiSw/UFOqET+pJ7KEu/m2dQTQPCtIoODiVVAD5S7oTKeg==",
+    "node_modules/@wordpress/latex-to-mathml": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.1.0.tgz",
+      "integrity": "sha512-WE8DB3lFi6VkE5Ssx22YPWjTTnbzsYx5JELN6QmjCuqgMMBKxLFDfL6qLn45IIyjRDMmN5/QpXMJM8aD9klnog==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/private-apis": "^1.31.0"
+        "temml": "^0.10.33"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/media-utils/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/media-utils": {
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.33.0.tgz",
+      "integrity": "sha512-gNvvZScdlxqJ0ghd8b4qhL9RrxnBTqWxu2OHlPeyGcg48AX8q/EWuDM7s2R4jCAIjHzrpPdDqy0+aB9o0fcanw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/private-apis": "^1.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.31.0.tgz",
-      "integrity": "sha512-dU8ARG3UP1PSmPMfQNrz1DpDIn5xuW6t1J+mVkyAbq2o1+Fs72Fsmi6hXPc0ut+P0pGTmsASzIeo7CzZUihmGw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.33.0.tgz",
+      "integrity": "sha512-MZjEQSf2iGiG1wB/nUmclFgcVWTHcvAjYJOrsDPeD63h3MGaVS6wunEf5QopCb4c4Cwd7/c90FtZvchvHtwpeg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/data": "^10.31.0"
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/data": "^10.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11878,21 +11728,10 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/notices/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.33.0.tgz",
-      "integrity": "sha512-XejRL8yPGoBVY44gvfH2A2STzFDUjzT7inxhsqzZWYgpMtDNjgdrRN6fgA1GP1nyQx0iRg28r/vapjFCWCA+5w==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.33.1.tgz",
+      "integrity": "sha512-0pVfOe2DHtqXBB91eNqf/mKtfq8qZAbqT7lHKYsbfgozaGN7pKHyUkWOzgs6dZMju2mImPn6oXzrkuOZtvTBcg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -11904,25 +11743,26 @@
       }
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.31.0.tgz",
-      "integrity": "sha512-y6ZC9jnh69p3XNTusvCHN8R05eSAZw91EnEBvxyKvzd0dtRG9f6Pxx/IhXZqp4nvtR3oIutgVW2sMq2LcpE0kg==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.33.0.tgz",
+      "integrity": "sha512-+jzPFT2R7avnnTVrLa11Yx7AYaDT+wH0owyxuII0ObmazSc6EHIcgq0iro9dyBquL9envE+3qiP4Dmq+UM/TwQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0"
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11933,30 +11773,33 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/patterns/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/patterns/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/plugins": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.31.0.tgz",
-      "integrity": "sha512-0Hm06PfeFlMqNvtu5pAfTCpiYLD+PEPfag9W08F0XhcJHFfqnlpGp8OeWGGOQif91cu9CRKU080MSDK1jvDJhQ==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.33.0.tgz",
+      "integrity": "sha512-VHDnfdcwqUUsIbwW1x06jaNlpNNMyCIplvudm2VSIW+hsCUZA6V6BlUpcXeMzmytVn2q/OZJkD/ISHxnx2vUGg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
         "memize": "^2.0.1"
       },
       "engines": {
@@ -11968,25 +11811,28 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/plugins/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.33.0.tgz",
-      "integrity": "sha512-VBmXyBpjq96L58ox5Fmhc2lMKuLZafqkz8im34gQOthjw8PwkHXDCcC/q5ue5SzYXvX07UTZnGGuc7V6ARrHLg==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.33.1.tgz",
+      "integrity": "sha512-mlxJflCUP3An6UXCQY137HajhQTKxPn+lL+p2PgeAtv6PVhwc8Gmv1RJP2QiGIPxrmI/KzrmHubSMjK1LYA12A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/base-styles": "^6.9.1",
         "autoprefixer": "^10.4.20",
         "postcss-import": "^16.1.1"
       },
@@ -11999,20 +11845,21 @@
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.31.0.tgz",
-      "integrity": "sha512-Ex1bftTy7cY+f+pfl2vaWu82QYBlkwHmJaPGQyRC0GKHiHrVHpfx7VOfwDuRAZ7ARHDWj284Ms4WGpyK0P5Yhg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.33.0.tgz",
+      "integrity": "sha512-l3B2uzQ6OiFzSOcSqS2Bn2XvatOB0DU19AdCDQ3ZHh+Ei/AcyPMJRQ3HX37coHUcSfzX+/EZNSKPnDVyw5uEOw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/private-apis": "^1.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/private-apis": "^1.33.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -12024,21 +11871,24 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/preferences/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.33.0.tgz",
-      "integrity": "sha512-PRNb10ouWjg52yeWHTXlaZqkuHMSHlKq9Risg368f5fWU7akDJgZboiD6jVdtv+iGXdFRlI5oRF31wqArzNykA==",
+      "version": "4.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.33.1.tgz",
+      "integrity": "sha512-Ws68H2+jVR31VSYqEfSlot7QeWHMlB+5ZQRLaEi8oX9vQgl/Auuxhudf41vfkGoZsSx9U2qq6l/6YxhPXR5kww==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -12050,12 +11900,12 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.31.0.tgz",
-      "integrity": "sha512-cY4EKYQRqHu9NZuoWchxc/KWiofwGskzxz0oCfgbdkRlfTag8yBjWMayz+fRNaenw0l5pzLyIg3rcNDN8xLezw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.33.0.tgz",
+      "integrity": "sha512-gK5/L+Yz5JmsJBwFd/pMb4zQoOYkhNkMAdhFCm9akn/qG/zrP+UlligxNYVbC+HhgOT6Jg932gcu2KqWkEYoSw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/element": "^6.31.0",
+        "@wordpress/element": "^6.33.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -12066,23 +11916,12 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/primitives/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.31.0.tgz",
-      "integrity": "sha512-OuHq9iGB8wppHfoMHs4g07Cc2yh2DyyqySDn+bpyXPbDcuqxU9s9EgjY08ZVjJEYMuFz2sjC16HlOFqv3NBYAg==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.33.0.tgz",
+      "integrity": "sha512-/tfjwy1IdjS7JGb5OMvkbkToXURmfDGwp/FZhenCMZfQFZqiriA1KjYCKLeMQgjsJ5ezf/2lq/KF6wdr0sYg4w==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "requestidlecallback": "^0.3.0"
       },
       "engines": {
@@ -12090,46 +11929,22 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/priority-queue/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.31.0.tgz",
-      "integrity": "sha512-OS/OvnUFj2QKeAsPGwgzETLPQhN8Ek1AC3q7rpuu+kZhZxB5hOsHDF/759XxH0fGPL/n0/Xqo4ZlnVYwPwqMPg==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.33.0.tgz",
+      "integrity": "sha512-GpkgZp4Kr99K4CvtVU3oQoHi8ku+hBGf4bd1zNCgoZLlihFWVYxE7TmUX6cy32YvZFNjlgc3wpWTW7lVpsJAGg==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/private-apis/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.31.0.tgz",
-      "integrity": "sha512-J16NmvIxWMU4lJMWrAshLCac5qjIs1QZnSzQXNKBXxg78ZjB7sa5Q9Qb8/aYxFVIIzTvpvDQVyHhHPcUnB4KYA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.33.0.tgz",
+      "integrity": "sha512-I3VWtOdiXsQqQZIt8aCIe3qaYxZfQJo1DBdQKscxxWOF/J5OLDfM3psKsTD0fs6g4rulCbDgFfIxI7bOxdXSoQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
         "rungen": "^0.3.2"
@@ -12142,34 +11957,24 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/redux-routine/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.31.0.tgz",
-      "integrity": "sha512-jDGEqkLSNEUAjVpurLdPiDdcqG5N0t+CDGUke8J5hegV4XLSMOEfXI6xSg44EHNRx1NakvRLXtCnT5/6vIV8Pw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.33.0.tgz",
+      "integrity": "sha512-lw9gjK1zu9oVq9aNwayiZKwv0L80Rku923nXuz7o4heqsK6ew0emxBf405qRilcBDFe3/BNOsmgZbiRj14hEcg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0"
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -12180,31 +11985,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.31.0.tgz",
-      "integrity": "sha512-s1CHb9vFYxa/fOPXSMn8GauOYb+gSVczHHx06Hj86JilGNAKmALADqzR+6D6ACKjahQypduYsF9P669PY7+PrQ==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.33.0.tgz",
+      "integrity": "sha512-+0QmR5iWH8RcJkCkMKmnZQwmMe6uK2rnl2FHsX0XAKQZxNVo9Mq5kNXFfN1CQOUrBwSmV86qjmjUYpaSEo0Teg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/keycodes": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/keycodes": "^4.33.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -12216,36 +12024,23 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/rich-text/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/escape-html": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-      "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+      "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-      "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+      "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0"
+        "@wordpress/i18n": "^6.6.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -12253,15 +12048,15 @@
       }
     },
     "node_modules/@wordpress/router": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.31.0.tgz",
-      "integrity": "sha512-NeEWZg+VU7EdbNYosDcpcSEx8vgizDCCKwm5qRVj4S6MtuYR7ZWZu5oXm4QdDCZjUytKv6gnuklAQO+xLRsDww==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.33.0.tgz",
+      "integrity": "sha512-WbP/Gm3cnFbSy/DztZDBe6Vb58hKVYNITTPGwIUPq5y1gE+/Y8E2f5avMCrt1LEDg8u3sC5E609HtaYBmOzHOA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
         "history": "^5.3.0",
         "route-recognizer": "^0.3.4"
       },
@@ -12273,37 +12068,26 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/router/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/scripts": {
-      "version": "30.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.26.0.tgz",
-      "integrity": "sha512-RpyF41xHtA4ktOP0JBBb6/MkoB7/H/emqQnO3t+dZFs56jCP/8141MicDl7Ne9PY29D4NaB0LgbcmthK5Msk1Q==",
+      "version": "30.26.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.26.1.tgz",
+      "integrity": "sha512-lJUd7PlvuCj78Jdt5lSyHKdIf1XxE1+2RBPUHrXYcn6wU78mLLR1LY+kOmPSmrk0QrHqsTACfOVvxcWFstmjMQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.33.0",
-        "@wordpress/browserslist-config": "^6.33.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.33.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.33.0",
-        "@wordpress/eslint-plugin": "^22.19.0",
-        "@wordpress/jest-preset-default": "^12.33.0",
-        "@wordpress/npm-package-json-lint-config": "^5.33.0",
-        "@wordpress/postcss-plugins-preset": "^5.33.0",
-        "@wordpress/prettier-config": "^4.33.0",
-        "@wordpress/stylelint-config": "^23.25.0",
+        "@wordpress/babel-preset-default": "^8.33.1",
+        "@wordpress/browserslist-config": "^6.33.1",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.33.1",
+        "@wordpress/e2e-test-utils-playwright": "^1.33.1",
+        "@wordpress/eslint-plugin": "^22.19.1",
+        "@wordpress/jest-preset-default": "^12.33.1",
+        "@wordpress/npm-package-json-lint-config": "^5.33.1",
+        "@wordpress/postcss-plugins-preset": "^5.33.1",
+        "@wordpress/prettier-config": "^4.33.1",
+        "@wordpress/stylelint-config": "^23.25.1",
         "adm-zip": "^0.5.9",
         "babel-jest": "29.7.0",
         "babel-loader": "9.2.1",
@@ -13389,20 +13173,20 @@
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.7.0.tgz",
-      "integrity": "sha512-Qa2ZEnksWIeWOIG8pFj5mgqFgbDYyH7gjx5cU9XibGcnJY6CHYwS+o9fODfkt1i2gQHT+17Yv0i4hQvFo5tLLg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.9.0.tgz",
+      "integrity": "sha512-QDqLQnp+Cg8GDslJxkWV0XA/QK8CIxgub7Q4ZLH/U02PMOjuuFvBQG58oGVv+yTo1rJST+6CiJN1ZDy4izqJLA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/url": "^4.31.0"
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/url": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13413,23 +13197,12 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/server-side-render/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.31.0.tgz",
-      "integrity": "sha512-ITusd7CSFL41NMRgAygCmopj+Du0OyHM/5uH6IbBBYHsXwkUiV5B3wt3023td8GcdhzVQPHVHEHqC2gyrttxEg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.33.0.tgz",
+      "integrity": "sha512-lYa9CXyKitW+Ko90U+BK+/X/VDTFidS2Vml3fqqi90FEeIZvFxzfREdnMeFLyZgJHn8kaQGb6ZVObuCtvUKJtQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "memize": "^2.0.1"
       },
       "engines": {
@@ -13437,23 +13210,12 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/shortcode/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.31.0.tgz",
-      "integrity": "sha512-kBGSLVZXWTTOJvEH6BrAWBkJJGBgFb7bq540pmi8RBTS8De3G6EZiufst+UDAlE6C2LC0E0264IzckUdKTE1oA==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.33.0.tgz",
+      "integrity": "sha512-WGFsvPKX/+9jkxw3B2kRXw3FP0/OLdBjk9ybgk25jy3O+Zj+txgPEMVc41y/P2DE5wU8P6Fn6I86F0Bd6OZNUA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "change-case": "^4.1.2"
       },
       "engines": {
@@ -13461,21 +13223,10 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/style-engine/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.25.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.25.0.tgz",
-      "integrity": "sha512-GefqayI9kSohIwYW6xkK8jZTF62k71ALdMSVgktMXru567gUDpb1Ci79CIY4iTK3fq/OpJW3uAM4AfXYNH8+3Q==",
+      "version": "23.25.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.25.1.tgz",
+      "integrity": "sha512-vFOnmuvP2DVKrM13WKJcruX0veZ8NS/1KMgIjCxQOdVqIQxIvJgkygdhC9ZhzRC9g4y8GqMJ0dmRZUg1XWKnjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13493,13 +13244,14 @@
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.31.0.tgz",
-      "integrity": "sha512-CYb3ayrrsQ7ttEi9zDVm+x0JJx7kRW6Fb/+tkCI1WKJBrxvRZbNK/QrT604AoWICeGi0j5baFoKUWxkibj1xFg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.33.0.tgz",
+      "integrity": "sha512-sBJmEn+Tex8FwvwyB/fUMvs85JfM4TxxbjTrWwzJ6dY9EKBbm6EUAE7GQ3oLk/tLaWtSea6uFAHmj5K5xj8nkA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "@types/simple-peer": "^9.11.5",
-        "@wordpress/url": "^4.31.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/url": "^4.33.0",
         "import-locals": "^2.0.0",
         "lib0": "^0.2.42",
         "simple-peer": "^9.11.0",
@@ -13513,79 +13265,44 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/sync/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/token-list": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.31.0.tgz",
-      "integrity": "sha512-pkeXS3xyY6uT0e23cSbreTdTNBsLRxdhMzCXINeM98GfBki5+fwxDxQhwqox5hVRJvo+Gy25Kg1oNhqdGFyAjw==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
-      },
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.33.0.tgz",
+      "integrity": "sha512-j8d+Q1Zme9yORhxG42ojAxJEa1l2L/fQ3USXc5gbgfwms4QVoe+6JVHlmrgFxSd863dUl1KRtNOMfIT8FYPajA==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/token-list/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.31.0.tgz",
-      "integrity": "sha512-4jsvLaf+O/AMX/2m34BHS4Jz/Z+9vfxkNLP0mhuqftOWRC66XFseMqU19VszQypL7VxWKMahenYqZw4O22JNnQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.33.0.tgz",
+      "integrity": "sha512-0QU8ElPAf50mEp95dnqQfUnby0ybxNs5Ukd3OYoxal5+lvGCOpBMf+L4zWLp8VGr5uLPL8ER12DdaBczXfXfPg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/is-shallow-equal": "^5.31.0"
+        "@wordpress/is-shallow-equal": "^5.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/undo-manager/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.16.0.tgz",
-      "integrity": "sha512-4ug8Ysm/cukAYQTt5MCTpY3yPaM0hB9HWf8SttUYVTfKacTCWbg2bRg5RihojDnB+zZVwmygTvVXmn3jFxSU+Q==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.18.0.tgz",
+      "integrity": "sha512-vxPIoJ4lUcGhdGOEAkKstNhVw2O34t4OAIfY7fWSXFCq7AGDutSVypzy0XgUOEV4AMxYIRgpZ+LGKZ/K9sb1MA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
         "uuid": "^9.0.1"
       },
       "engines": {
@@ -13597,17 +13314,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/upload-media/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/upload-media/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -13616,16 +13322,17 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.31.0.tgz",
-      "integrity": "sha512-fI0TK7WsGB3hgal/3PuoSN8zrato1hJz0r2xZQTe7+DWgrO3R8zlsoKhtOGzLL/zTNM5Auw22EPvRxGcwGT5zA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.33.0.tgz",
+      "integrity": "sha512-RKBrMc4bXfJDu5l9Ry2kTOtq83Y/EbGn+AMBrqhbDdRI7xxK3XuCmAbaC/vhjC7dWfdwzs7m16knFGeG87BKYw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
         "remove-accents": "^0.5.0"
       },
       "engines": {
@@ -13633,26 +13340,15 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/url/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/viewport": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.31.0.tgz",
-      "integrity": "sha512-lqQCXHQpFTawJjvus3trUYm2tVxWU1lTza1a5HWOtQaKFqKs9lP3Bpv0ViMPNv77m0fldnDNsFRMAVIVUedh5g==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.33.0.tgz",
+      "integrity": "sha512-DXvp0mNmIiA7y/Uon6B+49jMFVKHdBKVeddonl0KU6wD0zoKvGwTgne0Cz5tfQm0/7Y7qj62rMFYpyrKczHBQQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0"
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -13662,21 +13358,10 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/viewport/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@wordpress/warning": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.33.0.tgz",
-      "integrity": "sha512-LzYgKfxgK5YEpTu4zHPCDzw+kH5hYCrKRK/joK8S9booy5ERvzRCPrISMwrmAKTD9esYF82+IEHhW0/qsjxPsw==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.33.1.tgz",
+      "integrity": "sha512-ciDPM0AEu1s3xjDUwiTRxWiY0sTKTXI4R8NYO57g9+RuP4M5JnLK5/mdLVFCiWNo27tkUPFAgzHop7ssj3inew==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -13684,22 +13369,23 @@
       }
     },
     "node_modules/@wordpress/widgets": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.31.0.tgz",
-      "integrity": "sha512-bhFyLEl0+2ZSnCUK/+/TO0agyWL5kK3uPIWL1m3i/WFoKgoF2rtZDlEMhQcsKbLSwvMllegu5sJZHWawZnL4Cw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.33.0.tgz",
+      "integrity": "sha512-3kTbhlA9UbiashHqeQkkqroBBDgaJHYACCCoyhMVaNCl6ey0GE3dv25MFLyw7wdITiwStsuYx8J7m0smS2jtMg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/notices": "^5.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/notices": "^5.33.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -13711,38 +13397,28 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/widgets/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+    "node_modules/@wordpress/widgets/node_modules/@wordpress/icons": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+      "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@wordpress/wordcount": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.31.0.tgz",
-      "integrity": "sha512-2FUbfYxaTYq+LGLkPzGWq51tI4lTf6/gzflxSqbJpl6sSzbFwfuGhC/hAc4upaY4atHH5CD4k/dBS9eBHKo+7Q==",
-      "dependencies": {
-        "@babel/runtime": "7.25.7"
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/primitives": "^4.33.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/wordcount/node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+    "node_modules/@wordpress/wordcount": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.33.0.tgz",
+      "integrity": "sha512-2cEFC//RitqaRTomAUW4w6Ri5Czahoxmgq17n6Mg6tLU9I4XK6c6FP4Z7IHJxIVIH3+DtGzJN+okGJXjOe2pag==",
+      "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -14051,6 +13727,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
       "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -14312,13 +13989,14 @@
       "license": "MIT"
     },
     "node_modules/atomically": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
-      "integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
+      "integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "stubborn-fs": "^1.2.5",
-        "when-exit": "^2.1.1"
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "node_modules/autoprefixer": {
@@ -15174,6 +14852,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -15636,7 +15315,8 @@
     "node_modules/client-zip": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.5.0.tgz",
-      "integrity": "sha512-ydG4nDZesbFurnNq0VVCp/yyomIBh+X/1fZPI/P24zbnG4dtC4tQAfI5uQsomigsUMeiRO2wiTPizLWQh+IAyQ=="
+      "integrity": "sha512-ydG4nDZesbFurnNq0VVCp/yyomIBh+X/1fZPI/P24zbnG4dtC4tQAfI5uQsomigsUMeiRO2wiTPizLWQh+IAyQ==",
+      "license": "MIT"
     },
     "node_modules/clipboard": {
       "version": "2.0.11",
@@ -15704,6 +15384,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
       "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.6",
@@ -17281,7 +16962,8 @@
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1507524",
@@ -17650,7 +17332,8 @@
     "node_modules/err-code": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -18932,6 +18615,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.0.tgz",
       "integrity": "sha512-nC6x2YIlJ9xxgkMFMd1BNoM1ctMjNoRKfRliPmiEWW3S6rLTHiQcy9g3pt/xiKv/D0NAAkhb9VyV+WJFvTqMGg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -19643,7 +19327,8 @@
     "node_modules/get-browser-rtc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
-      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -19684,6 +19369,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -20142,6 +19828,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -20583,7 +20270,8 @@
     "node_modules/import-locals": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-locals/-/import-locals-2.0.0.tgz",
-      "integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA=="
+      "integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==",
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -21233,6 +20921,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -24731,6 +24420,7 @@
       "version": "0.2.114",
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -24856,16 +24546,16 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core": {
-      "version": "24.26.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.26.1.tgz",
-      "integrity": "sha512-YHZdo3chJ5b9pTYVnuDuoI3UX/tWJFJyRZvkLbThGy6XeHWC+0KI8iN0UMCkvde5l/YOk3huiVZ/PvwgSbwdrA==",
+      "version": "24.27.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.27.0.tgz",
+      "integrity": "sha512-yubwj2XXmTM3wRIpbhO5nCjbByPgpFHlgrsD4IK+gMPqO7/a5FfnoSXDKjmqi8A2M1Ewusz0rTI/r+IN0GU0MA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.12",
         "chromium-bidi": "10.5.1",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1508733",
+        "devtools-protocol": "0.0.1521046",
         "typed-query-selector": "^2.12.0",
         "webdriver-bidi-protocol": "0.3.8",
         "ws": "^8.18.3"
@@ -24875,9 +24565,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1508733",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
-      "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
+      "version": "0.0.1521046",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
+      "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -25707,6 +25397,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -25715,6 +25406,7 @@
       "version": "0.5.48",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
       "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -27684,6 +27376,7 @@
       "version": "10.27.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
       "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -28234,6 +27927,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
       "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
         "react-style-singleton": "^2.2.3",
@@ -28258,6 +27952,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
@@ -28279,6 +27974,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
         "tslib": "^2.0.0"
@@ -28806,7 +28502,8 @@
     "node_modules/route-recognizer": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
-      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g=="
+      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
+      "license": "MIT"
     },
     "node_modules/rtlcss": {
       "version": "4.3.0",
@@ -29669,6 +29366,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "debug": "^4.3.2",
@@ -30302,9 +30000,19 @@
       }
     },
     "node_modules/stubborn-fs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
-      "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.1.tgz",
+      "integrity": "sha512-bwtct4FpoH1eYdSMFc84fxnYynWwsy2u0joj94K+6caiPnjZIpwTLHT2u7CFAS0GumaBZVB5Y2GkJ46mJS76qg==",
       "dev": true
     },
     "node_modules/style-search": {
@@ -30889,6 +30597,15 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/temml": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.10.34.tgz",
+      "integrity": "sha512-f3b5CaPwPvMviA+CtHy0qoIGWvzpRrNpXmGRc/Y1jc9gAYy+xOlndJFyn7Vfcz7cBcS8QRvv8z0EEH59sHCQxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.13.0"
       }
     },
     "node_modules/terser": {
@@ -31769,6 +31486,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -31797,6 +31515,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -32479,9 +32198,9 @@
       }
     },
     "node_modules/when-exit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.4.tgz",
-      "integrity": "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
       "dev": true,
       "license": "MIT"
     },
@@ -32808,6 +32527,7 @@
       "version": "9.0.12",
       "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
       "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.74"
       },
@@ -32827,6 +32547,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
       "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -32846,6 +32567,7 @@
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.6.tgz",
       "integrity": "sha512-1kZ4YYwksFZi8+l8mTebVX9vW6Q5MnqxMkvNU700X5dBE38usurt/JgeXSIQRpK3NwUYYb9y63Jn9FMpMH6/vA==",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42",
         "simple-peer": "^9.11.0",
@@ -32933,6 +32655,7 @@
       "version": "13.6.27",
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
       "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -38196,9 +37919,9 @@
       "dev": true
     },
     "@types/simple-peer": {
-      "version": "9.11.8",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.8.tgz",
-      "integrity": "sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==",
+      "version": "9.11.9",
+      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.9.tgz",
+      "integrity": "sha512-6Gdl7TSS5oh9nuwKD4Pl8cSmaxWycYeZz9HLnJBNvIwWjZuGVsmHe9RwW3+9RxfhC1aIR9Z83DvaJoMw6rhkbg==",
       "requires": {
         "@types/node": "*"
       }
@@ -39701,67 +39424,43 @@
       "dev": true
     },
     "@wordpress/a11y": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.31.0.tgz",
-      "integrity": "sha512-LU2Ea+RRaqe1Q8u15Y1dBxXfGwPsOtqXLZR7Bfk7y9yMsJnKqymovR7yvoPYe/4dWXy0B9sK1jUJtPAMUFfOng==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.33.0.tgz",
+      "integrity": "sha512-LUFmuDkwKS15XkV8ziR2isSMvgLZjyRg0EQD4lfCywS9ycQzuzGFHDzUxpg0ECjYQfRrGDzMcPQe5ts8HuklOA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/dom-ready": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/dom-ready": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0"
+      }
+    },
+    "@wordpress/admin-ui": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-1.1.0.tgz",
+      "integrity": "sha512-YhzlNXI8DT8u8N2idtE5mWwmnVvJAKZqw4QaGFT/TO5LLrPFEmfYFqhFMTwnYUFfocgjW2qP0FI1OtDw6KFjjQ==",
+      "requires": {
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/element": "^6.33.0",
+        "clsx": "^2.1.1"
       }
     },
     "@wordpress/api-fetch": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.31.0.tgz",
-      "integrity": "sha512-mEnNA2QvLeopNfXhRYaaCyF6Db1zZUaQI/+3UIJCn66OasoNQnvPHyHxWCRegsDfdtL7tCyvSuAbB++9wzcDyQ==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.33.0.tgz",
+      "integrity": "sha512-1hUMnX7t+PFBgNNZIITOY8w9J3/ZcVm3sT2gxURPaz1B1BE7LwLwQQyqUWi6hl4Z0eh5qUcEG5HJOUZTGLmVwA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/url": "^4.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/url": "^4.33.0"
       }
     },
     "@wordpress/autop": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.31.0.tgz",
-      "integrity": "sha512-PzmFe0gePKxdld01Nk/9quklzEZCshyCncs2uVaAzCXQ8jvubQo7Z9QYXHjY8ukHXCG+RyaYuj+PJrimV6iX2A==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.33.0.tgz",
+      "integrity": "sha512-F7639N+pjPQDATwKVRSgZPOvdfeunbAO/wOKvDrQ8DAObgAcbFwz1iTtNw9chiB8/r7/x31TzPU1QxHbjn9xeA=="
     },
     "@wordpress/babel-preset-default": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.33.0.tgz",
-      "integrity": "sha512-zi+TfLm7w8UmC/IE1b6/z+GIRMvv9s6yQ7+2a3XUEFriAiLwVM2cRXTcauaKkcos3BDi35M0V8x0T7980RwTlQ==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.33.1.tgz",
+      "integrity": "sha512-nB/vm8bNgrJbMyX5YaCafeXjKs1LVVde886bVWf9lnIhlDhkAqF9qZN2Hd5B6h1JbQJp7Kc0bFSROXDcS/JZpw==",
       "dev": true,
       "requires": {
         "@babel/core": "7.25.7",
@@ -39770,8 +39469,8 @@
         "@babel/plugin-transform-runtime": "7.25.7",
         "@babel/preset-env": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
-        "@wordpress/browserslist-config": "^6.33.0",
-        "@wordpress/warning": "^3.33.0",
+        "@wordpress/browserslist-config": "^6.33.1",
+        "@wordpress/warning": "^3.33.1",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.0"
@@ -39916,69 +39615,56 @@
       }
     },
     "@wordpress/base-styles": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.0.tgz",
-      "integrity": "sha512-z3WCO0EdVWrXkEn6QXlFQZoKyPxplIctOWTqG8KPLtdHa0gqXhF+gaNxwGg6Ao2ac4sqoFSBcKPhXgE/08jK7g=="
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.9.1.tgz",
+      "integrity": "sha512-UCtTANAdym5jpTEZS17WHrKLu7R52gQRgKuwsRm5uZWUb4g4Vq8NX52CBIesF1viFyKfM++HpmteFkrL7p0SMg=="
     },
     "@wordpress/blob": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.31.0.tgz",
-      "integrity": "sha512-14QzAp4tTFowxMgNjz2refH6ziGTX4TBfpDyTs+/grNzOhRlOlUOSx7u2S7zZekWzp/A6nsGklGr3ACrpkrDXA==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.33.0.tgz",
+      "integrity": "sha512-ZgrzNRsSyi5tpOBhHlmjd4131PTKH7E+1z9BF3eeyo+3nQAvkTU1hdHQ7yJpbF/7Ss1FeTjF+qvKoB25p9c1/w=="
     },
     "@wordpress/block-editor": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.4.0.tgz",
-      "integrity": "sha512-vBnxrrT4UJ+gum5Z8oS3s8ULqjKlXrkHOrwQEVjc+8+wTwp1qePzCttA08eVqAFsO9JzeseIhiJkUAEhezFwIQ==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.6.0.tgz",
+      "integrity": "sha512-Y+BXztP8RBaACBSrYG3aXuuLA+w46B1azLK5qluZms7TyBG7nyS7n0WDLeTIejfNvzJjy3lwKJ9nJSETjrBUfg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-serialization-default-parser": "^5.31.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/commands": "^1.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/priority-queue": "^3.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/style-engine": "^2.31.0",
-        "@wordpress/token-list": "^3.31.0",
-        "@wordpress/upload-media": "^0.16.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
-        "@wordpress/wordcount": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-serialization-default-parser": "^5.33.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/commands": "^1.33.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/priority-queue": "^3.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/style-engine": "^2.33.0",
+        "@wordpress/token-list": "^3.33.0",
+        "@wordpress/upload-media": "^0.18.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
+        "@wordpress/wordcount": "^4.33.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -39995,72 +39681,70 @@
         "remove-accents": "^0.5.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/escape-html": {
-          "version": "3.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-          "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+          "version": "3.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+          "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ=="
+        },
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "@babel/runtime": "7.25.7"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         }
       }
     },
     "@wordpress/block-library": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.31.0.tgz",
-      "integrity": "sha512-BlqpLwn4zyUauwrkOO2agHD9Xo93jZcdapqk0IzvbYR9BoJJIZjj3JKp8huc5diVS79KkS590rqs7Yk6sZJWNg==",
+      "version": "9.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.33.1.tgz",
+      "integrity": "sha512-SQ5jW0OJwEy4LIL16V5SK39wWgyKt4A8y1Ye070nwcZmamTIvg1wqypITtwqXfJVAX9YUZvicX3Vb3KOZ6nAfQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/autop": "^4.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/interactivity": "^6.31.0",
-        "@wordpress/interactivity-router": "^2.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/patterns": "^2.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/reusable-blocks": "^5.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/server-side-render": "^6.7.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/viewport": "^6.31.0",
-        "@wordpress/wordcount": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/autop": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/interactivity": "^6.33.0",
+        "@wordpress/interactivity-router": "^2.33.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/latex-to-mathml": "^1.1.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/patterns": "^2.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/reusable-blocks": "^5.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/server-side-render": "^6.9.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/viewport": "^6.33.0",
+        "@wordpress/wordcount": "^4.33.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -40072,29 +39756,26 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/escape-html": {
-          "version": "3.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-          "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+          "version": "3.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+          "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ=="
+        },
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "@babel/runtime": "7.25.7"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         },
         "uuid": {
@@ -40105,44 +39786,30 @@
       }
     },
     "@wordpress/block-serialization-default-parser": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.31.0.tgz",
-      "integrity": "sha512-38pHFz1ugJtYuuSxK7AxFzkmuZbUpSrylNrhjmWv12e0z5aYDNs8jtiii4CPeWD3RPvXEuYpwsOHR/4hTyuFMQ==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.33.0.tgz",
+      "integrity": "sha512-kVtx1zX9/vOWvxU3U1d9jTrjkrB9Z2r2qnkEl8p5E3nSiUrPIvLxPnzPa9KRuRma9uNVH//YUc59kgVxRSALIQ=="
     },
     "@wordpress/blocks": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.4.0.tgz",
-      "integrity": "sha512-hY/oofLfM0zujjQ9vvL7M9hzrW9xTc+MqHvwtAa0jZwCUWVKRY+jGUKp7HpZNcYtF+szR4LXATqS+kqcUAlARg==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.6.0.tgz",
+      "integrity": "sha512-w3O88J9xZ4b+ATCqEnc2RTc+euAtsuAcwHchopLn4MAZcynG/AU7h9HZ6nE6EMPJX1Dv34GJZvQxxMUM4K16zA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/autop": "^4.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-serialization-default-parser": "^5.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/shortcode": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/autop": "^4.33.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-serialization-default-parser": "^5.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/shortcode": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -40156,14 +39823,6 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "react-is": {
           "version": "18.3.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -40177,45 +39836,45 @@
       }
     },
     "@wordpress/browserslist-config": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.33.0.tgz",
-      "integrity": "sha512-4plw8mLKjcd1beuJzmjT4GNBk+R02qu/og6h/BuGMY8dxfqovfGB0Z2w7C85ILmjY2qnvsU7gelDcSXNgwuwxQ==",
+      "version": "6.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.33.1.tgz",
+      "integrity": "sha512-JVqhw9fK79eztAGRbZd2Cr0JX39vv8a/4Y7oE0iQFst105tyOJP3koMeKZa7x4EJWnbUPNrFFVmwpt/JcaPENw==",
       "dev": true
     },
     "@wordpress/commands": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.31.0.tgz",
-      "integrity": "sha512-PaBQVIHNGBn2sMxPj5ILJPAe4h79MvUcb5DzgiXA+H+0nNHLsQxg2u8Cfm2spct37dqOLMnQ6PVMRS+SwCLESQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.33.0.tgz",
+      "integrity": "sha512-EJM2QdC0xQp6lVaCybbCQhkaX7/it5cEvYXvLtSSRMbCreu8OhCBvd2IruT8+5QIgnAgBHQkc589SsdW3DNsaA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/components": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.4.0.tgz",
-      "integrity": "sha512-PrZ8+VMCciVkWna//AH55Xg+TALw/E67358B5w/qiBohZ0CaoL1z4UcltkO+Gd5BJ1E14HbD8vC/6ao8dMXEJg==",
+      "version": "30.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.6.0.tgz",
+      "integrity": "sha512-RkY+DIW+iy1Y5jiVYxfs9mNY+noV9AwPlKySJRsVy5o9u7k52HayuNe9cMl5/UsXLNgWHLMUykEZGkgHgNeaRA==",
       "requires": {
         "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "7.25.7",
         "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.7.1",
         "@emotion/react": "^11.7.1",
@@ -40226,23 +39885,24 @@
         "@types/gradient-parser": "1.1.0",
         "@types/highlight-words-core": "1.2.1",
         "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -40262,29 +39922,26 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/escape-html": {
-          "version": "3.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-          "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+          "version": "3.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+          "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ=="
+        },
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "@babel/runtime": "7.25.7"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         },
         "uuid": {
@@ -40295,66 +39952,55 @@
       }
     },
     "@wordpress/compose": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.31.0.tgz",
-      "integrity": "sha512-kxb1qHhiFwUDifBM9r4JZ3gYC1ZUvck5tgjmaWeg8EqIEnVn+Z7C+ntNA9ySLWrmDYc4Gki7YJZbfVHzrtcDLg==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.33.0.tgz",
+      "integrity": "sha512-ICBdgush3DXFWN7VMxTy/3LCK+qpyGMnNhX+XIl3LVug5yOfT77G9JA3Mbpw2cwpihyDdekItlsE0f4rYL/nnA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/priority-queue": "^3.31.0",
-        "@wordpress/undo-manager": "^1.31.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/priority-queue": "^3.33.0",
+        "@wordpress/undo-manager": "^1.33.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         }
       }
     },
     "@wordpress/core-data": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.31.0.tgz",
-      "integrity": "sha512-Rp/LcmTwBL8uITYmj2HRV6GGT1MKvRvaU594fq+CTZa9kNYDUwhnG7xtC9+JbjPSdZ9zLtHVQUdKbwRvpkcibw==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.33.0.tgz",
+      "integrity": "sha512-Lwde8zJHPvWD6DJFjwM9uYXS0ZvyuG23QVOARYcrWezytQdnXIBRQ70oVa5xfGfd0OSKrIoWBhjWHzJLP+DJRA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/sync": "^1.31.0",
-        "@wordpress/undo-manager": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/sync": "^1.33.0",
+        "@wordpress/undo-manager": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -40362,14 +40008,6 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -40378,18 +40016,17 @@
       }
     },
     "@wordpress/data": {
-      "version": "10.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.31.0.tgz",
-      "integrity": "sha512-iuQxrmbW55q+xy7lnXH8D6qHFAoG0/YcnjZ6jvqpDekRhdgl4kAPE+crx/kJ5RkrIIo38a+cLgVskCaKo+9E3w==",
+      "version": "10.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.33.0.tgz",
+      "integrity": "sha512-05USk5y+UoGBW5xEVLWLUJOZsMTMmFRagsdgijV+RETzRj1qTw0Vj3y/mhH49EQ16s7fkPMmcCbZnSiGvATD7g==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
-        "@wordpress/priority-queue": "^3.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/redux-routine": "^5.31.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
+        "@wordpress/priority-queue": "^3.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/redux-routine": "^5.33.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -40399,14 +40036,6 @@
         "use-memo-one": "^1.1.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "redux": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -40415,25 +40044,24 @@
       }
     },
     "@wordpress/dataviews": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-9.0.0.tgz",
-      "integrity": "sha512-epjNwINFMsql3FG8bhBVkQlPeUzUTgTvkLYrGzmCwM18nLu4L17bbvfhRMG/Nx+49SO+hd8bN2Rcgj3RG7eATg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-10.1.0.tgz",
+      "integrity": "sha512-RYjPsO56xayphKgGLWa1KDrDDx9YFlRlwcJH2EVppFzsu657wK8z7FfLF0lwDsRdnhPQ2sW+db6LmQrnfmK3yQ==",
       "requires": {
         "@ariakit/react": "^0.4.15",
-        "@babel/runtime": "7.25.7",
-        "@wordpress/base-styles": "^6.7.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
         "date-fns": "^4.1.0",
@@ -40442,21 +40070,21 @@
         "remove-accents": "^0.5.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         },
         "date-fns": {
@@ -40467,30 +40095,19 @@
       }
     },
     "@wordpress/date": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.31.0.tgz",
-      "integrity": "sha512-xqKytkb60N9i+ETqTI+Asgb1myZIgnUne8zsGaYQU+B7H1M3ELw4lmc+ptDXjXrpI1Yb6BGUad4EIHBGVk+mog==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.33.0.tgz",
+      "integrity": "sha512-pcZjaytspcLLQIN2cnrK51Zgv4lm/s1qLu/tLEmNg9DeVL3mKsWNBE6JFSmSJzPLQUHtH7k174RwY8g1bBDTbA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.31.0",
+        "@wordpress/deprecated": "^4.33.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.33.0.tgz",
-      "integrity": "sha512-uGvJrak1wpi6XAfIvSXedXgfxvavpzVlj7ypAedAqQ26eFLHCPzK9S2TRp+jw4BglUE3mR2NXD8/glorbGwq+g==",
+      "version": "6.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.33.1.tgz",
+      "integrity": "sha512-JyTopRN6TrXOjcu5VVLhpED0tkuMyY1jIMy6oRfPmxPFP52/ulVmBFiaqYtigGuOSsXlbW4SJsU637GOgCUZUw==",
       "dev": true,
       "requires": {
         "json2php": "^0.0.7"
@@ -40505,65 +40122,30 @@
       }
     },
     "@wordpress/deprecated": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.31.0.tgz",
-      "integrity": "sha512-bbDrL2lp7crFfvmJ1EYVxPDcheTIwimt3gVzqQWCDr0SSCQw4fii5NEKOrUnWhz51YCuPbfWXUBaFlbAMS2CXw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.33.0.tgz",
+      "integrity": "sha512-+9RD5oAAH+HGh6YwRJui0mj/WOfxSZi1/0l2YdgKuQsY2DhnJbEscc/86IxSR44IEMItKjIoJO3k9CdeyFyRig==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/hooks": "^4.33.0"
       }
     },
     "@wordpress/dom": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.31.0.tgz",
-      "integrity": "sha512-5/RBy9OreQktnBE75cB3R6Lva5c6hUlXvPo1NFfAebLeXX+7swZBmLYZnyf7dZbARRdqSwkundHZoKLcHa+20A==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.33.0.tgz",
+      "integrity": "sha512-lXF9NiBkiw1uFdUdAmQBxnnIUsFZxxJM2tLTXpRrPBWtB77e1rdmz0xVWBYDHr8FaaOXQ/30TuvhAiNPsbISfg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/deprecated": "^4.33.0"
       }
     },
     "@wordpress/dom-ready": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.31.0.tgz",
-      "integrity": "sha512-aRM4l5wzkrqAU686s4fz1bb+/7/BOFp+sXB0kx1vkiXl3ocfmHAr3jwEYU+OH/sX6Is3Ntkfh0uZe3EJLsqHTQ==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.33.0.tgz",
+      "integrity": "sha512-NDmtk+n0ZoWW0KzPHNSGYfKB/NM2EVxP2HwkBE8tN3+G7Z/hktdcpFiRTPhYoDg2KIAZMngBOzckgGtcIJ3z3A=="
     },
     "@wordpress/e2e-test-utils-playwright": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.33.0.tgz",
-      "integrity": "sha512-OuxF/5TeHh2k58jsKRG2AtFhoRgAFKUrOjcrBLaNew3Y6RepwvLLgSq1LXqUrR1nhJU90AaH6AqFrJ2s+lmFUw==",
+      "version": "1.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.33.1.tgz",
+      "integrity": "sha512-ra3JHLuTHJviE50JVMmKViK2qS53sMNhUuG2+vY9zVI69BzEbzajLW/4BnUB0c1HF16h0PW4oZL9m9V4Pi6KXA==",
       "dev": true,
       "requires": {
         "change-case": "^4.1.2",
@@ -40575,103 +40157,105 @@
       }
     },
     "@wordpress/edit-post": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.31.0.tgz",
-      "integrity": "sha512-hPNmXDaVMfVk2BM070xpYUuTKZFm4cr7NcQLcbWc1TjXHx1HOWpB/rjdUUTaDsEn1Ox3+yH5qh4O+309el3NYw==",
+      "version": "8.33.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.33.2.tgz",
+      "integrity": "sha512-/uI8ONhsZd0CYoyi5/p9Imss3eOfRYN6AoMMjXMN8m3usGWkWxYYQFT34p792Rz2rosBlof90YINLFfXX6U+EQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/block-library": "^9.31.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/commands": "^1.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/editor": "^14.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/plugins": "^7.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/viewport": "^6.31.0",
-        "@wordpress/warning": "^3.31.0",
-        "@wordpress/widgets": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/admin-ui": "^1.1.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/block-library": "^9.33.1",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/commands": "^1.33.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/editor": "^14.33.2",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/plugins": "^7.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/viewport": "^6.33.0",
+        "@wordpress/warning": "^3.33.0",
+        "@wordpress/widgets": "^4.33.0",
         "clsx": "^2.1.1",
         "memize": "^2.1.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         }
       }
     },
     "@wordpress/editor": {
-      "version": "14.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.31.0.tgz",
-      "integrity": "sha512-J5D0EmTMuw0YUer0t8fgC1n/Avuu+TbCtfJoQLgCcI4Bi6ZwjiKpoooBDBpKCVqCV+Xut3R9thLaSJcyDVpTrA==",
+      "version": "14.33.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.33.2.tgz",
+      "integrity": "sha512-B49leSFoH6W6pSDHMtn74JBBVVeukdungut9hI6fnEscELiBUmQPAe5Gxnr1S9PDbTYVa6sLdNZoJNXXzFlcHA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/commands": "^1.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/dataviews": "^9.0.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/dom": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/fields": "^0.23.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/interface": "^9.16.0",
-        "@wordpress/keyboard-shortcuts": "^5.31.0",
-        "@wordpress/keycodes": "^4.31.0",
-        "@wordpress/media-utils": "^5.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/patterns": "^2.31.0",
-        "@wordpress/plugins": "^7.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/reusable-blocks": "^5.31.0",
-        "@wordpress/rich-text": "^7.31.0",
-        "@wordpress/server-side-render": "^6.7.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
-        "@wordpress/wordcount": "^4.31.0",
+        "@floating-ui/react-dom": "2.0.8",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/commands": "^1.33.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/dataviews": "^10.1.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/dom": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/fields": "^0.25.2",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/interface": "^9.18.0",
+        "@wordpress/keyboard-shortcuts": "^5.33.0",
+        "@wordpress/keycodes": "^4.33.0",
+        "@wordpress/media-utils": "^5.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/patterns": "^2.33.0",
+        "@wordpress/plugins": "^7.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/reusable-blocks": "^5.33.0",
+        "@wordpress/rich-text": "^7.33.0",
+        "@wordpress/server-side-render": "^6.9.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
+        "@wordpress/wordcount": "^4.33.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
@@ -40685,21 +40269,21 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         },
         "uuid": {
@@ -40710,35 +40294,23 @@
       }
     },
     "@wordpress/element": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.31.0.tgz",
-      "integrity": "sha512-KOier6Y4b4Y5yEV1GYen81R9gCEOvJT6eVbsc93w2fFEKi2FK/oI7IKzGv9GeJMkoCWvTSX6C/ZYTWk6fCUfeA==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.33.0.tgz",
+      "integrity": "sha512-vUcH12viRpHkqZ1j3kEqE3bnCvl0tsvUUgp9USgeqRx9YE+8XAn6MdghvwF65/R2It66vqogJlKnbO4wfXehTA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.31.0",
+        "@wordpress/escape-html": "^3.33.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/escape-html": {
-          "version": "3.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-          "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
-          "requires": {
-            "@babel/runtime": "7.25.7"
-          }
+          "version": "3.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+          "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ=="
         },
         "react-dom": {
           "version": "18.3.1",
@@ -40768,16 +40340,16 @@
       }
     },
     "@wordpress/eslint-plugin": {
-      "version": "22.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.19.0.tgz",
-      "integrity": "sha512-J24RZ6U4Ref0ix8uhmc3XJGkJLdi/V+JOQjjRwB0uLpsSHio4+LhAJrBlovkZCf+0HsRKiJHuIdli0EKW5gl3g==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.19.1.tgz",
+      "integrity": "sha512-7rMkG4nk+nVLaRJxbR4/XYlTPHJT/3IeMyK9eZpKFJgBvL/NQbOC1Oq0n8VZHp1U/Q8csAl/uABJZ9EKLeDMnA==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "7.25.7",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^8.33.0",
-        "@wordpress/prettier-config": "^4.33.0",
+        "@wordpress/babel-preset-default": "^8.33.1",
+        "@wordpress/prettier-config": "^4.33.1",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -40808,107 +40380,71 @@
       }
     },
     "@wordpress/fields": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.23.0.tgz",
-      "integrity": "sha512-Nc6c8JlITyO9Y1CJKs0KN7YZbGi11ITeJNVT/WCjhgi7HlDk+hDHuJaIZCNxiTICspDiVQKiVBcN/c0CQ1uv1A==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.25.2.tgz",
+      "integrity": "sha512-Z23pnkJ0NTdlubzXAj2Kd4OsBDzfSCXByzPKYDNlw8mm5OlTJYiGgYmk2AMN82NQbmAqhm/VB90rq+ufRbNAyg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/dataviews": "^9.0.0",
-        "@wordpress/date": "^5.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/media-utils": "^5.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/patterns": "^2.31.0",
-        "@wordpress/primitives": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/router": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
-        "@wordpress/warning": "^3.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/dataviews": "^10.1.0",
+        "@wordpress/date": "^5.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/media-utils": "^5.33.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/patterns": "^2.33.0",
+        "@wordpress/primitives": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/router": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
+        "@wordpress/warning": "^3.33.0",
         "change-case": "4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "2.1.1",
         "remove-accents": "^0.5.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/hooks": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.31.0.tgz",
-      "integrity": "sha512-8YOftWP54V4hvO46/FgXnpiB/fAC72CWD/F1JYtcfZcrWgbR96MGZxKXNvn5BgLx6juO36QQuFhJ5y2ZUEulkw==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.33.0.tgz",
+      "integrity": "sha512-UwYLO+d3B2a9YtyiKTKjpE+j+eXI1pgySUutD8DL9DnHZMKX/TY4pBdSH4tyNMYxA2Jx0HBDhxBWVkE6e2KB6A=="
     },
     "@wordpress/html-entities": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.31.0.tgz",
-      "integrity": "sha512-5dk9h16jSXDTSdk0HnyXEOgZd7VSsMtr3YCSUQvzIYOFkpW2q1eB10coXHiuz0Z5ArlTuNYSfBd2J02xnG+a8g==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.33.0.tgz",
+      "integrity": "sha512-BidF5J9hvxWe/OUqw/k8+aVnZ8KykUIYYix9V5LpFQIq2Y3pC/W344t/vXY5hRZELz9ojBJVft6bClsIbjCdoQ=="
     },
     "@wordpress/i18n": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.4.0.tgz",
-      "integrity": "sha512-tLTjdLw8H778K4fmEo5NDLYJOAgvHxgfLU5N7lPuBy2TKi8tQl24xgmJOlDLiMzbmbSEwvUBZ/4xWJsGq9ITDQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.6.0.tgz",
+      "integrity": "sha512-tPbvLiOl09M2NBt+pKA2bRUH5GEAzSPHt6cNEF1vbDPSIrtcv/B76x3uRE/hEb6gz67HW594fyAwV7ES/4hZhA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.31.0",
+        "@wordpress/hooks": "^4.33.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/icons": {
@@ -40932,88 +40468,76 @@
       }
     },
     "@wordpress/interactivity": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.31.0.tgz",
-      "integrity": "sha512-5qpjRrlvF7sV3r9pUi3Y3fMD07/aeBA8zj4AmMgnRvTAw87580bszwNcUKVChDzVP8Bjpi2QMHGvhY36aXjFpQ==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.33.0.tgz",
+      "integrity": "sha512-KrwM685gGE8t2D4jM1JuQlPySzDx2QFo4cFJhQgDLEgl15fvx+l8Y2uVKO1yx0AxLRHdtuXEqfdQFVMLGEUOYw==",
       "requires": {
         "@preact/signals": "^1.3.0",
         "preact": "^10.24.2"
       }
     },
     "@wordpress/interactivity-router": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.31.0.tgz",
-      "integrity": "sha512-j3KDaT97kQcbW5JH1Nf+SeaoCWEbo8JfNkf+6U8sZl76D5mjx8K+AGQjMnJhgGDXYrutpDl+1XjwqBvA0NDFqg==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.33.0.tgz",
+      "integrity": "sha512-vrmdoV2c0Qmqe9F/1rQUCRkQBeEAvow7pB3H5BZX2pkegbbexp0PIQtBkL1GV4HdNNMyDBnBlpYlbw8vvDOVmg==",
       "requires": {
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/interactivity": "^6.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/interactivity": "^6.33.0",
         "es-module-lexer": "^1.5.4"
       }
     },
     "@wordpress/interface": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.16.0.tgz",
-      "integrity": "sha512-VWuYYpYz+J9kN6U1qhE1Te4JKSMEb0OvKSrb9+ErDNLYM5f9yVcPlOXmbwnGcAGYMRxZn7S+kUpBHMqp7jUz2w==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.18.0.tgz",
+      "integrity": "sha512-U89Wsl/6miZXEfurhVF8MLYW80t1yUqORmP22+5NKmx76WJ+66kw1ptANta2dgR+uZr6hWn2Yu/Zwx1GyG/XNA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/plugins": "^7.31.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/viewport": "^6.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/admin-ui": "^1.1.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/plugins": "^7.33.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/viewport": "^6.33.0",
         "clsx": "^2.1.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/is-shallow-equal": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.31.0.tgz",
-      "integrity": "sha512-jqGEw+5DLNf2kNbjaNxIKWQGYkqxygRYDYTdhZ+f+Btw/gMKILJq0sZGRD8YjJFGG0cOC2qxtJnr9oF36Iu96Q==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.33.0.tgz",
+      "integrity": "sha512-nd8yAVFXnPw4V91MjHQ58eEc/wiDHh4KplUfWzfLd2EesLbRlrtFcZyXe4NkeMlGk+Prfy7wJyNNrax17sBCBQ=="
     },
     "@wordpress/jest-console": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.33.0.tgz",
-      "integrity": "sha512-G9mJYPpGokk+G5MCM2xMQzHqmZY2DNTFDxtJnmH4ISHm4+2S2OTsHovTNuOM+n8QqaaB2En4uuBfYykpRQfNlw==",
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.33.1.tgz",
+      "integrity": "sha512-oJaw7Uf3ZICLNhTeHSV6zYnicL1op70YQPPF95fP25wMa9RLiwWlJvbsIp1iZw1VWoIQi6uQXOLfTSkvHvqeEg==",
       "dev": true,
       "requires": {
         "jest-matcher-utils": "^29.6.2"
       }
     },
     "@wordpress/jest-preset-default": {
-      "version": "12.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.33.0.tgz",
-      "integrity": "sha512-TI3FHvMyWeC36IBz7lGaADLIHrSow9Yj80jwisWZ1uppWkAh1wwnJuGnMUn6dSydUolCGitLcMBjA/kGx3uPLw==",
+      "version": "12.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.33.1.tgz",
+      "integrity": "sha512-z5/2wf6ImYx2o3UEEEr+PNQkHul96Jo9U2ncljDHNckV38WJprqJJvHZdL53U9nRs92YgdVn0lR/mfIO/jYpZg==",
       "dev": true,
       "requires": {
-        "@wordpress/jest-console": "^8.33.0",
+        "@wordpress/jest-console": "^8.33.1",
         "babel-jest": "29.7.0"
       },
       "dependencies": {
@@ -41057,31 +40581,21 @@
       }
     },
     "@wordpress/keyboard-shortcuts": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.31.0.tgz",
-      "integrity": "sha512-7rEarvwA93+tNC/HPTMK5kuXLBHSSOXgKJz3H2ZPCsYnk6Jf34QeMHOsCJvzA8MuMbx+TBihpEM8JkAkeko60w==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.33.0.tgz",
+      "integrity": "sha512-hFCHRlhPUOlpoXB6R2Wt3QPFJnqN6GutVjMAXnbduWk9m9KCfRiGs/K7N718PtHjX90COrODoumr3/ybHs1iGQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/keycodes": "^4.31.0"
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/keycodes": "^4.33.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         }
       }
@@ -41118,353 +40632,272 @@
         }
       }
     },
-    "@wordpress/media-utils": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.31.0.tgz",
-      "integrity": "sha512-41O67AO/axvxYbrCp/rgGsYTrSbIWd7b7IC3R7nlSCiSw/UFOqET+pJ7KEu/m2dQTQPCtIoODiVVAD5S7oTKeg==",
+    "@wordpress/latex-to-mathml": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.1.0.tgz",
+      "integrity": "sha512-WE8DB3lFi6VkE5Ssx22YPWjTTnbzsYx5JELN6QmjCuqgMMBKxLFDfL6qLn45IIyjRDMmN5/QpXMJM8aD9klnog==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/private-apis": "^1.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "temml": "^0.10.33"
+      }
+    },
+    "@wordpress/media-utils": {
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.33.0.tgz",
+      "integrity": "sha512-gNvvZScdlxqJ0ghd8b4qhL9RrxnBTqWxu2OHlPeyGcg48AX8q/EWuDM7s2R4jCAIjHzrpPdDqy0+aB9o0fcanw==",
+      "requires": {
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/private-apis": "^1.33.0"
       }
     },
     "@wordpress/notices": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.31.0.tgz",
-      "integrity": "sha512-dU8ARG3UP1PSmPMfQNrz1DpDIn5xuW6t1J+mVkyAbq2o1+Fs72Fsmi6hXPc0ut+P0pGTmsASzIeo7CzZUihmGw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.33.0.tgz",
+      "integrity": "sha512-MZjEQSf2iGiG1wB/nUmclFgcVWTHcvAjYJOrsDPeD63h3MGaVS6wunEf5QopCb4c4Cwd7/c90FtZvchvHtwpeg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/data": "^10.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/data": "^10.33.0"
       }
     },
     "@wordpress/npm-package-json-lint-config": {
-      "version": "5.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.33.0.tgz",
-      "integrity": "sha512-XejRL8yPGoBVY44gvfH2A2STzFDUjzT7inxhsqzZWYgpMtDNjgdrRN6fgA1GP1nyQx0iRg28r/vapjFCWCA+5w==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.33.1.tgz",
+      "integrity": "sha512-0pVfOe2DHtqXBB91eNqf/mKtfq8qZAbqT7lHKYsbfgozaGN7pKHyUkWOzgs6dZMju2mImPn6oXzrkuOZtvTBcg==",
       "dev": true
     },
     "@wordpress/patterns": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.31.0.tgz",
-      "integrity": "sha512-y6ZC9jnh69p3XNTusvCHN8R05eSAZw91EnEBvxyKvzd0dtRG9f6Pxx/IhXZqp4nvtR3oIutgVW2sMq2LcpE0kg==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.33.0.tgz",
+      "integrity": "sha512-+jzPFT2R7avnnTVrLa11Yx7AYaDT+wH0owyxuII0ObmazSc6EHIcgq0iro9dyBquL9envE+3qiP4Dmq+UM/TwQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/html-entities": "^4.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0"
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/html-entities": "^4.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/plugins": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.31.0.tgz",
-      "integrity": "sha512-0Hm06PfeFlMqNvtu5pAfTCpiYLD+PEPfag9W08F0XhcJHFfqnlpGp8OeWGGOQif91cu9CRKU080MSDK1jvDJhQ==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.33.0.tgz",
+      "integrity": "sha512-VHDnfdcwqUUsIbwW1x06jaNlpNNMyCIplvudm2VSIW+hsCUZA6V6BlUpcXeMzmytVn2q/OZJkD/ISHxnx2vUGg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/hooks": "^4.31.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/is-shallow-equal": "^5.31.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/is-shallow-equal": "^5.33.0",
         "memize": "^2.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/postcss-plugins-preset": {
-      "version": "5.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.33.0.tgz",
-      "integrity": "sha512-VBmXyBpjq96L58ox5Fmhc2lMKuLZafqkz8im34gQOthjw8PwkHXDCcC/q5ue5SzYXvX07UTZnGGuc7V6ARrHLg==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.33.1.tgz",
+      "integrity": "sha512-mlxJflCUP3An6UXCQY137HajhQTKxPn+lL+p2PgeAtv6PVhwc8Gmv1RJP2QiGIPxrmI/KzrmHubSMjK1LYA12A==",
       "dev": true,
       "requires": {
-        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/base-styles": "^6.9.1",
         "autoprefixer": "^10.4.20",
         "postcss-import": "^16.1.1"
       }
     },
     "@wordpress/preferences": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.31.0.tgz",
-      "integrity": "sha512-Ex1bftTy7cY+f+pfl2vaWu82QYBlkwHmJaPGQyRC0GKHiHrVHpfx7VOfwDuRAZ7ARHDWj284Ms4WGpyK0P5Yhg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.33.0.tgz",
+      "integrity": "sha512-l3B2uzQ6OiFzSOcSqS2Bn2XvatOB0DU19AdCDQ3ZHh+Ei/AcyPMJRQ3HX37coHUcSfzX+/EZNSKPnDVyw5uEOw==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/private-apis": "^1.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/private-apis": "^1.33.0",
         "clsx": "^2.1.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/prettier-config": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.33.0.tgz",
-      "integrity": "sha512-PRNb10ouWjg52yeWHTXlaZqkuHMSHlKq9Risg368f5fWU7akDJgZboiD6jVdtv+iGXdFRlI5oRF31wqArzNykA==",
+      "version": "4.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.33.1.tgz",
+      "integrity": "sha512-Ws68H2+jVR31VSYqEfSlot7QeWHMlB+5ZQRLaEi8oX9vQgl/Auuxhudf41vfkGoZsSx9U2qq6l/6YxhPXR5kww==",
       "dev": true
     },
     "@wordpress/primitives": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.31.0.tgz",
-      "integrity": "sha512-cY4EKYQRqHu9NZuoWchxc/KWiofwGskzxz0oCfgbdkRlfTag8yBjWMayz+fRNaenw0l5pzLyIg3rcNDN8xLezw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.33.0.tgz",
+      "integrity": "sha512-gK5/L+Yz5JmsJBwFd/pMb4zQoOYkhNkMAdhFCm9akn/qG/zrP+UlligxNYVbC+HhgOT6Jg932gcu2KqWkEYoSw==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/element": "^6.31.0",
+        "@wordpress/element": "^6.33.0",
         "clsx": "^2.1.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/priority-queue": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.31.0.tgz",
-      "integrity": "sha512-OuHq9iGB8wppHfoMHs4g07Cc2yh2DyyqySDn+bpyXPbDcuqxU9s9EgjY08ZVjJEYMuFz2sjC16HlOFqv3NBYAg==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.33.0.tgz",
+      "integrity": "sha512-/tfjwy1IdjS7JGb5OMvkbkToXURmfDGwp/FZhenCMZfQFZqiriA1KjYCKLeMQgjsJ5ezf/2lq/KF6wdr0sYg4w==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "requestidlecallback": "^0.3.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/private-apis": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.31.0.tgz",
-      "integrity": "sha512-OS/OvnUFj2QKeAsPGwgzETLPQhN8Ek1AC3q7rpuu+kZhZxB5hOsHDF/759XxH0fGPL/n0/Xqo4ZlnVYwPwqMPg==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.33.0.tgz",
+      "integrity": "sha512-GpkgZp4Kr99K4CvtVU3oQoHi8ku+hBGf4bd1zNCgoZLlihFWVYxE7TmUX6cy32YvZFNjlgc3wpWTW7lVpsJAGg=="
     },
     "@wordpress/redux-routine": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.31.0.tgz",
-      "integrity": "sha512-J16NmvIxWMU4lJMWrAshLCac5qjIs1QZnSzQXNKBXxg78ZjB7sa5Q9Qb8/aYxFVIIzTvpvDQVyHhHPcUnB4KYA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.33.0.tgz",
+      "integrity": "sha512-I3VWtOdiXsQqQZIt8aCIe3qaYxZfQJo1DBdQKscxxWOF/J5OLDfM3psKsTD0fs6g4rulCbDgFfIxI7bOxdXSoQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
         "rungen": "^0.3.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/reusable-blocks": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.31.0.tgz",
-      "integrity": "sha512-jDGEqkLSNEUAjVpurLdPiDdcqG5N0t+CDGUke8J5hegV4XLSMOEfXI6xSg44EHNRx1NakvRLXtCnT5/6vIV8Pw==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.33.0.tgz",
+      "integrity": "sha512-lw9gjK1zu9oVq9aNwayiZKwv0L80Rku923nXuz7o4heqsK6ew0emxBf405qRilcBDFe3/BNOsmgZbiRj14hEcg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/notices": "^5.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0"
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/notices": "^5.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/rich-text": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.31.0.tgz",
-      "integrity": "sha512-s1CHb9vFYxa/fOPXSMn8GauOYb+gSVczHHx06Hj86JilGNAKmALADqzR+6D6ACKjahQypduYsF9P669PY7+PrQ==",
+      "version": "7.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.33.0.tgz",
+      "integrity": "sha512-+0QmR5iWH8RcJkCkMKmnZQwmMe6uK2rnl2FHsX0XAKQZxNVo9Mq5kNXFfN1CQOUrBwSmV86qjmjUYpaSEo0Teg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/a11y": "^4.31.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/escape-html": "^3.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/keycodes": "^4.31.0",
+        "@wordpress/a11y": "^4.33.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/escape-html": "^3.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/keycodes": "^4.33.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "@wordpress/escape-html": {
-          "version": "3.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-          "integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
-          "requires": {
-            "@babel/runtime": "7.25.7"
-          }
+          "version": "3.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.33.0.tgz",
+          "integrity": "sha512-AyVgImB3tX7a6gtnvJVjuRXwD1E7mrVPHWoz2PA3ZrvilXPpfwx8AsJWnrZMeUaOlEHELjqsHZCpJMZhfkO7YQ=="
         },
         "@wordpress/keycodes": {
-          "version": "4.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.31.0.tgz",
-          "integrity": "sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==",
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.33.0.tgz",
+          "integrity": "sha512-XsKjGvh95pllYZefXo3c1FL9OpX9PxdQ724KPtjRI3X070N8TJgpp3iVyNpF1xZJMn7dmACDE/Wp13VBAu24Cw==",
           "requires": {
-            "@babel/runtime": "7.25.7",
-            "@wordpress/i18n": "^6.4.0"
+            "@wordpress/i18n": "^6.6.0"
           }
         }
       }
     },
     "@wordpress/router": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.31.0.tgz",
-      "integrity": "sha512-NeEWZg+VU7EdbNYosDcpcSEx8vgizDCCKwm5qRVj4S6MtuYR7ZWZu5oXm4QdDCZjUytKv6gnuklAQO+xLRsDww==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.33.0.tgz",
+      "integrity": "sha512-WbP/Gm3cnFbSy/DztZDBe6Vb58hKVYNITTPGwIUPq5y1gE+/Y8E2f5avMCrt1LEDg8u3sC5E609HtaYBmOzHOA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
         "history": "^5.3.0",
         "route-recognizer": "^0.3.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/scripts": {
-      "version": "30.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.26.0.tgz",
-      "integrity": "sha512-RpyF41xHtA4ktOP0JBBb6/MkoB7/H/emqQnO3t+dZFs56jCP/8141MicDl7Ne9PY29D4NaB0LgbcmthK5Msk1Q==",
+      "version": "30.26.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.26.1.tgz",
+      "integrity": "sha512-lJUd7PlvuCj78Jdt5lSyHKdIf1XxE1+2RBPUHrXYcn6wU78mLLR1LY+kOmPSmrk0QrHqsTACfOVvxcWFstmjMQ==",
       "dev": true,
       "requires": {
         "@babel/core": "7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.33.0",
-        "@wordpress/browserslist-config": "^6.33.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.33.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.33.0",
-        "@wordpress/eslint-plugin": "^22.19.0",
-        "@wordpress/jest-preset-default": "^12.33.0",
-        "@wordpress/npm-package-json-lint-config": "^5.33.0",
-        "@wordpress/postcss-plugins-preset": "^5.33.0",
-        "@wordpress/prettier-config": "^4.33.0",
-        "@wordpress/stylelint-config": "^23.25.0",
+        "@wordpress/babel-preset-default": "^8.33.1",
+        "@wordpress/browserslist-config": "^6.33.1",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.33.1",
+        "@wordpress/e2e-test-utils-playwright": "^1.33.1",
+        "@wordpress/eslint-plugin": "^22.19.1",
+        "@wordpress/jest-preset-default": "^12.33.1",
+        "@wordpress/npm-package-json-lint-config": "^5.33.1",
+        "@wordpress/postcss-plugins-preset": "^5.33.1",
+        "@wordpress/prettier-config": "^4.33.1",
+        "@wordpress/stylelint-config": "^23.25.1",
         "adm-zip": "^0.5.9",
         "babel-jest": "29.7.0",
         "babel-loader": "9.2.1",
@@ -42209,74 +41642,41 @@
       }
     },
     "@wordpress/server-side-render": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.7.0.tgz",
-      "integrity": "sha512-Qa2ZEnksWIeWOIG8pFj5mgqFgbDYyH7gjx5cU9XibGcnJY6CHYwS+o9fODfkt1i2gQHT+17Yv0i4hQvFo5tLLg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.9.0.tgz",
+      "integrity": "sha512-QDqLQnp+Cg8GDslJxkWV0XA/QK8CIxgub7Q4ZLH/U02PMOjuuFvBQG58oGVv+yTo1rJST+6CiJN1ZDy4izqJLA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/deprecated": "^4.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/url": "^4.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/deprecated": "^4.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/url": "^4.33.0"
       }
     },
     "@wordpress/shortcode": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.31.0.tgz",
-      "integrity": "sha512-ITusd7CSFL41NMRgAygCmopj+Du0OyHM/5uH6IbBBYHsXwkUiV5B3wt3023td8GcdhzVQPHVHEHqC2gyrttxEg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.33.0.tgz",
+      "integrity": "sha512-lYa9CXyKitW+Ko90U+BK+/X/VDTFidS2Vml3fqqi90FEeIZvFxzfREdnMeFLyZgJHn8kaQGb6ZVObuCtvUKJtQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "memize": "^2.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/style-engine": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.31.0.tgz",
-      "integrity": "sha512-kBGSLVZXWTTOJvEH6BrAWBkJJGBgFb7bq540pmi8RBTS8De3G6EZiufst+UDAlE6C2LC0E0264IzckUdKTE1oA==",
+      "version": "2.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.33.0.tgz",
+      "integrity": "sha512-WGFsvPKX/+9jkxw3B2kRXw3FP0/OLdBjk9ybgk25jy3O+Zj+txgPEMVc41y/P2DE5wU8P6Fn6I86F0Bd6OZNUA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "change-case": "^4.1.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/stylelint-config": {
-      "version": "23.25.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.25.0.tgz",
-      "integrity": "sha512-GefqayI9kSohIwYW6xkK8jZTF62k71ALdMSVgktMXru567gUDpb1Ci79CIY4iTK3fq/OpJW3uAM4AfXYNH8+3Q==",
+      "version": "23.25.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.25.1.tgz",
+      "integrity": "sha512-vFOnmuvP2DVKrM13WKJcruX0veZ8NS/1KMgIjCxQOdVqIQxIvJgkygdhC9ZhzRC9g4y8GqMJ0dmRZUg1XWKnjg==",
       "dev": true,
       "requires": {
         "@stylistic/stylelint-plugin": "^3.0.1",
@@ -42285,13 +41685,13 @@
       }
     },
     "@wordpress/sync": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.31.0.tgz",
-      "integrity": "sha512-CYb3ayrrsQ7ttEi9zDVm+x0JJx7kRW6Fb/+tkCI1WKJBrxvRZbNK/QrT604AoWICeGi0j5baFoKUWxkibj1xFg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.33.0.tgz",
+      "integrity": "sha512-sBJmEn+Tex8FwvwyB/fUMvs85JfM4TxxbjTrWwzJ6dY9EKBbm6EUAE7GQ3oLk/tLaWtSea6uFAHmj5K5xj8nkA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "@types/simple-peer": "^9.11.5",
-        "@wordpress/url": "^4.31.0",
+        "@wordpress/hooks": "^4.33.0",
+        "@wordpress/url": "^4.33.0",
         "import-locals": "^2.0.0",
         "lib0": "^0.2.42",
         "simple-peer": "^9.11.0",
@@ -42299,81 +41699,38 @@
         "y-protocols": "^1.0.5",
         "y-webrtc": "~10.2.5",
         "yjs": "~13.6.6"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/token-list": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.31.0.tgz",
-      "integrity": "sha512-pkeXS3xyY6uT0e23cSbreTdTNBsLRxdhMzCXINeM98GfBki5+fwxDxQhwqox5hVRJvo+Gy25Kg1oNhqdGFyAjw==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.33.0.tgz",
+      "integrity": "sha512-j8d+Q1Zme9yORhxG42ojAxJEa1l2L/fQ3USXc5gbgfwms4QVoe+6JVHlmrgFxSd863dUl1KRtNOMfIT8FYPajA=="
     },
     "@wordpress/undo-manager": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.31.0.tgz",
-      "integrity": "sha512-4jsvLaf+O/AMX/2m34BHS4Jz/Z+9vfxkNLP0mhuqftOWRC66XFseMqU19VszQypL7VxWKMahenYqZw4O22JNnQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.33.0.tgz",
+      "integrity": "sha512-0QU8ElPAf50mEp95dnqQfUnby0ybxNs5Ukd3OYoxal5+lvGCOpBMf+L4zWLp8VGr5uLPL8ER12DdaBczXfXfPg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/is-shallow-equal": "^5.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/is-shallow-equal": "^5.33.0"
       }
     },
     "@wordpress/upload-media": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.16.0.tgz",
-      "integrity": "sha512-4ug8Ysm/cukAYQTt5MCTpY3yPaM0hB9HWf8SttUYVTfKacTCWbg2bRg5RihojDnB+zZVwmygTvVXmn3jFxSU+Q==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.18.0.tgz",
+      "integrity": "sha512-vxPIoJ4lUcGhdGOEAkKstNhVw2O34t4OAIfY7fWSXFCq7AGDutSVypzy0XgUOEV4AMxYIRgpZ+LGKZ/K9sb1MA==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/blob": "^4.31.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/preferences": "^4.31.0",
-        "@wordpress/private-apis": "^1.31.0",
-        "@wordpress/url": "^4.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/blob": "^4.33.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/preferences": "^4.33.0",
+        "@wordpress/private-apis": "^1.33.0",
+        "@wordpress/url": "^4.33.0",
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -42382,97 +41739,63 @@
       }
     },
     "@wordpress/url": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.31.0.tgz",
-      "integrity": "sha512-fI0TK7WsGB3hgal/3PuoSN8zrato1hJz0r2xZQTe7+DWgrO3R8zlsoKhtOGzLL/zTNM5Auw22EPvRxGcwGT5zA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.33.0.tgz",
+      "integrity": "sha512-RKBrMc4bXfJDu5l9Ry2kTOtq83Y/EbGn+AMBrqhbDdRI7xxK3XuCmAbaC/vhjC7dWfdwzs7m16knFGeG87BKYw==",
       "requires": {
-        "@babel/runtime": "7.25.7",
         "remove-accents": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
       }
     },
     "@wordpress/viewport": {
-      "version": "6.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.31.0.tgz",
-      "integrity": "sha512-lqQCXHQpFTawJjvus3trUYm2tVxWU1lTza1a5HWOtQaKFqKs9lP3Bpv0ViMPNv77m0fldnDNsFRMAVIVUedh5g==",
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.33.0.tgz",
+      "integrity": "sha512-DXvp0mNmIiA7y/Uon6B+49jMFVKHdBKVeddonl0KU6wD0zoKvGwTgne0Cz5tfQm0/7Y7qj62rMFYpyrKczHBQQ==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0"
       }
     },
     "@wordpress/warning": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.33.0.tgz",
-      "integrity": "sha512-LzYgKfxgK5YEpTu4zHPCDzw+kH5hYCrKRK/joK8S9booy5ERvzRCPrISMwrmAKTD9esYF82+IEHhW0/qsjxPsw=="
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.33.1.tgz",
+      "integrity": "sha512-ciDPM0AEu1s3xjDUwiTRxWiY0sTKTXI4R8NYO57g9+RuP4M5JnLK5/mdLVFCiWNo27tkUPFAgzHop7ssj3inew=="
     },
     "@wordpress/widgets": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.31.0.tgz",
-      "integrity": "sha512-bhFyLEl0+2ZSnCUK/+/TO0agyWL5kK3uPIWL1m3i/WFoKgoF2rtZDlEMhQcsKbLSwvMllegu5sJZHWawZnL4Cw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.33.0.tgz",
+      "integrity": "sha512-3kTbhlA9UbiashHqeQkkqroBBDgaJHYACCCoyhMVaNCl6ey0GE3dv25MFLyw7wdITiwStsuYx8J7m0smS2jtMg==",
       "requires": {
-        "@babel/runtime": "7.25.7",
-        "@wordpress/api-fetch": "^7.31.0",
-        "@wordpress/block-editor": "^15.4.0",
-        "@wordpress/blocks": "^15.4.0",
-        "@wordpress/components": "^30.4.0",
-        "@wordpress/compose": "^7.31.0",
-        "@wordpress/core-data": "^7.31.0",
-        "@wordpress/data": "^10.31.0",
-        "@wordpress/element": "^6.31.0",
-        "@wordpress/i18n": "^6.4.0",
-        "@wordpress/icons": "^10.31.0",
-        "@wordpress/notices": "^5.31.0",
+        "@wordpress/api-fetch": "^7.33.0",
+        "@wordpress/base-styles": "^6.9.0",
+        "@wordpress/block-editor": "^15.6.0",
+        "@wordpress/blocks": "^15.6.0",
+        "@wordpress/components": "^30.6.0",
+        "@wordpress/compose": "^7.33.0",
+        "@wordpress/core-data": "^7.33.0",
+        "@wordpress/data": "^10.33.0",
+        "@wordpress/element": "^6.33.0",
+        "@wordpress/i18n": "^6.6.0",
+        "@wordpress/icons": "^11.0.0",
+        "@wordpress/notices": "^5.33.0",
         "clsx": "^2.1.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+        "@wordpress/icons": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.0.0.tgz",
+          "integrity": "sha512-vhhcQODgvNQ6Zj4Wa0PjM91IND9UgZXdUIp/NdTD4yUaCmRyWkXEYwAB3yT2OyO8iuQUlU/T6/uOcQQRD+AJ/g==",
           "requires": {
-            "regenerator-runtime": "^0.14.0"
+            "@wordpress/element": "^6.33.0",
+            "@wordpress/primitives": "^4.33.0"
           }
         }
       }
     },
     "@wordpress/wordcount": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.31.0.tgz",
-      "integrity": "sha512-2FUbfYxaTYq+LGLkPzGWq51tI4lTf6/gzflxSqbJpl6sSzbFwfuGhC/hAc4upaY4atHH5CD4k/dBS9eBHKo+7Q==",
-      "requires": {
-        "@babel/runtime": "7.25.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.25.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-          "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-          "requires": {
-            "regenerator-runtime": "^0.14.0"
-          }
-        }
-      }
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.33.0.tgz",
+      "integrity": "sha512-2cEFC//RitqaRTomAUW4w6Ri5Czahoxmgq17n6Mg6tLU9I4XK6c6FP4Z7IHJxIVIH3+DtGzJN+okGJXjOe2pag=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -42874,13 +42197,13 @@
       "dev": true
     },
     "atomically": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
-      "integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
+      "integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
       "dev": true,
       "requires": {
-        "stubborn-fs": "^1.2.5",
-        "when-exit": "^2.1.1"
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
       }
     },
     "autoprefixer": {
@@ -50265,24 +49588,24 @@
           }
         },
         "puppeteer-core": {
-          "version": "24.26.1",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.26.1.tgz",
-          "integrity": "sha512-YHZdo3chJ5b9pTYVnuDuoI3UX/tWJFJyRZvkLbThGy6XeHWC+0KI8iN0UMCkvde5l/YOk3huiVZ/PvwgSbwdrA==",
+          "version": "24.27.0",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.27.0.tgz",
+          "integrity": "sha512-yubwj2XXmTM3wRIpbhO5nCjbByPgpFHlgrsD4IK+gMPqO7/a5FfnoSXDKjmqi8A2M1Ewusz0rTI/r+IN0GU0MA==",
           "dev": true,
           "requires": {
             "@puppeteer/browsers": "2.10.12",
             "chromium-bidi": "10.5.1",
             "debug": "^4.4.3",
-            "devtools-protocol": "0.0.1508733",
+            "devtools-protocol": "0.0.1521046",
             "typed-query-selector": "^2.12.0",
             "webdriver-bidi-protocol": "0.3.8",
             "ws": "^8.18.3"
           },
           "dependencies": {
             "devtools-protocol": {
-              "version": "0.0.1508733",
-              "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
-              "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
+              "version": "0.0.1521046",
+              "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
+              "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
               "dev": true
             },
             "ws": {
@@ -54024,9 +53347,18 @@
       }
     },
     "stubborn-fs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
-      "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "requires": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "stubborn-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.1.tgz",
+      "integrity": "sha512-bwtct4FpoH1eYdSMFc84fxnYynWwsy2u0joj94K+6caiPnjZIpwTLHT2u7CFAS0GumaBZVB5Y2GkJ46mJS76qg==",
       "dev": true
     },
     "style-search": {
@@ -54418,6 +53750,11 @@
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
+    },
+    "temml": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.10.34.tgz",
+      "integrity": "sha512-f3b5CaPwPvMviA+CtHy0qoIGWvzpRrNpXmGRc/Y1jc9gAYy+xOlndJFyn7Vfcz7cBcS8QRvv8z0EEH59sHCQxg=="
     },
     "terser": {
       "version": "5.44.0",
@@ -55468,9 +54805,9 @@
       }
     },
     "when-exit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.4.tgz",
-      "integrity": "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
       "dev": true
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@wordpress/icons": "^10.31.0",
         "@wordpress/plugins": "^7.31.0",
         "@wordpress/url": "^4.31.0",
-        "ajv": "^8.17.1",
         "classnames": "^2.5.1",
         "dompurify": "^3.3.0",
         "prop-types": "^15.8.1",
@@ -13887,6 +13886,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18999,6 +18999,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24558,7 +24559,8 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -28642,6 +28644,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -42569,6 +42572,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -46177,7 +46181,8 @@
     "fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -50057,7 +50062,8 @@
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -52815,7 +52821,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "require-in-the-middle": {
       "version": "7.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "prop-types": "^15.8.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "save-dev": "^0.0.1-security",
         "swr": "^2.3.6",
         "uuid": "^13.0.0"
       },
@@ -29007,11 +29006,6 @@
         }
       }
     },
-    "node_modules/save-dev": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
-      "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -53041,11 +53035,6 @@
       "requires": {
         "neo-async": "^2.6.2"
       }
-    },
-    "save-dev": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
-      "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
     },
     "saxes": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "dompurify": "^3.3.0",
         "prop-types": "^15.8.1",
         "react": "^18.0.0",
-        "react-dom": "19.1.1",
+        "react-dom": "^18.0.0",
         "save-dev": "^0.0.1-security",
         "swr": "^2.3.6",
         "uuid": "^13.0.0"
@@ -28189,15 +28189,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz",
+      "integrity": "sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^18.0.0"
       }
     },
     "node_modules/react-easy-crop": {
@@ -29025,10 +29026,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -52502,11 +52506,12 @@
       }
     },
     "react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz",
+      "integrity": "sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==",
       "requires": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
       }
     },
     "react-easy-crop": {
@@ -53052,9 +53057,12 @@
       }
     },
     "scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "schema-utils": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "dompurify": "^3.3.0",
     "prop-types": "^15.8.1",
     "react": "^18.0.0",
-    "react-dom": "19.1.1",
+    "react-dom": "^18.0.0",
     "save-dev": "^0.0.1-security",
     "swr": "^2.3.6",
     "uuid": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "prop-types": "^15.8.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "save-dev": "^0.0.1-security",
     "swr": "^2.3.6",
     "uuid": "^13.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@wordpress/icons": "^10.31.0",
     "@wordpress/plugins": "^7.31.0",
     "@wordpress/url": "^4.31.0",
-    "ajv": "^8.17.1",
     "classnames": "^2.5.1",
     "dompurify": "^3.3.0",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
## Summary

Fixes #356

This pull request resolves version inconsistencies by downgrading `react-dom` to version 18 to match React v18. It also removes unnecessary dependencies from the project.

## Changes Made

- Updated `react-dom` dependency in `package.json` and `package-lock.json` from `19.1.1` to `^18.0.0` to ensure compatibility with React v18.
- Removed all references to the `save-dev` package from dependencies and lockfiles.
- Removed the `ajv` package, as it is no longer needed due to recent updates in the build tool.
- ran `npm audit fix`.

## How to Test

1. Review the updated `package.json` and `package-lock.json` to confirm that both React and React-DOM are set to version 18.
2. Run the project and verify that there are no compatibility issues between React and React-DOM.
3. Ensure the application builds and runs as expected without the removed packages (`ajv` and `save-dev`).

## Additional Notes

No additional notes.