### PR TITLE
Fix deduping logic when 'Show template' enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `WP Curate` will be documented in this file.
 ## Unreleased
 
 - Enhancement: Enable pinning scheduled posts via `wp_curate_include_future_posts` filter.
+- Bug fix: Fix issue where pinning a post would not update the preview in the editor when "Show template" was enabled.
 
 ## 3.0.0 - 2025-10-31
 

--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -99,8 +99,17 @@ export function mainDedupe() {
   // Clear the flag for another run.
   redo = false;
   resetUsedIds();
+
   // @ts-expect-error Methods not fully typed.
-  const blocks: Block[] = select(blockEditorStore).getBlocks();
+  const { getBlocksByName, getBlocks } = select(blockEditorStore);
+
+  /**
+   * There isn't support yet for deduplicating posts throughout an entire template.
+   * If we're in template mode, narrow the scope to just the blocks in post content.
+   */
+  const root: Block[] = getBlocksByName('core/post-content');
+  const blocks: Block[] = root.length === 1 ? getBlocks(root) : getBlocks();
+
   const {
     wp_curate_deduplication: wpCurateDeduplication = true,
     wp_curate_unique_pinned_posts: wpCurateUniquePinnedPosts = false,


### PR DESCRIPTION
When "Show template" is enabled in the editor, `getBlocks()` returns the blocks in the entire template. This tree includes the `core/post-content` block, but without its inner blocks. To get the blocks inside `core/post-content`, the block needs to be requested by client ID.

Fixes #394.