### PR TITLE
Issue-354: In Sidebar, swap locations for Select Posts and Query Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to `WP Curate` will be documented in this file.
 
 ## Unreleased
 
-Nothing yet.
+- Enhancement: Query Parameters listed before Select Posts in Query block sidebar, for a better user experience, as
+Select Posts duplicates functionality available in the main editor.
 
 ## 3.1.0 - 2025-11-24
 

--- a/components/QueryControls/index.tsx
+++ b/components/QueryControls/index.tsx
@@ -240,45 +240,6 @@ export default function QueryControls({
         </PanelBody>
 
         <PanelBody
-          title={__('Select Posts', 'wp-curate')}
-          initialOpen={false}
-          className="manual-posts"
-        >
-          {manualPosts.map((_post, index) => (
-            <PanelRow
-              // eslint-disable-next-line react/no-array-index-key
-              key={index}
-              className={classnames(
-                'manual-posts__container',
-                { 'manual-posts__container--selected': manualPosts[index] },
-              )}
-            >
-              <span className="manual-posts__counter">{index + 1}</span>
-              <PostPicker
-                allowedTypes={filtered ? postTypes : displayTypes.map((type) => type.value)}
-                onReset={() => setManualPost(0, index)}
-                onUpdate={(id: number) => { setManualPost(id, index); }}
-                value={manualPosts[index] || 0}
-                className="manual-posts__picker"
-                // @ts-ignore This function does work with this prop.
-                getPostType={includeFuturePosts ? postTypeWithFuture : null}
-                filters={(
-                  <SearchFilters
-                    shouldShowFilter={shouldShowFilter}
-                    filtered={filtered}
-                    setFiltered={setFiltered}
-                  />
-                )}
-                params={{
-                  ...params,
-                  wp_curate_include_future: Number(includeFuturePosts),
-                }}
-              />
-            </PanelRow>
-          ))}
-        </PanelBody>
-
-        <PanelBody
           title={__('Query Parameters', 'wp-curate')}
           initialOpen={false}
         >
@@ -380,6 +341,45 @@ export default function QueryControls({
               onChange={(next) => setAttributes({ orderby: next ? 'trending' : 'date', backfillPosts: [] })}
             />
           ) : null }
+        </PanelBody>
+
+        <PanelBody
+          title={__('Select Posts', 'wp-curate')}
+          initialOpen={false}
+          className="manual-posts"
+        >
+          {manualPosts.map((_post, index) => (
+            <PanelRow
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              className={classnames(
+                'manual-posts__container',
+                { 'manual-posts__container--selected': manualPosts[index] },
+              )}
+            >
+              <span className="manual-posts__counter">{index + 1}</span>
+              <PostPicker
+                allowedTypes={filtered ? postTypes : displayTypes.map((type) => type.value)}
+                onReset={() => setManualPost(0, index)}
+                onUpdate={(id: number) => { setManualPost(id, index); }}
+                value={manualPosts[index] || 0}
+                className="manual-posts__picker"
+                // @ts-ignore This function does work with this prop.
+                getPostType={includeFuturePosts ? postTypeWithFuture : null}
+                filters={(
+                  <SearchFilters
+                    shouldShowFilter={shouldShowFilter}
+                    filtered={filtered}
+                    setFiltered={setFiltered}
+                  />
+                )}
+                params={{
+                  ...params,
+                  wp_curate_include_future: Number(includeFuturePosts),
+                }}
+              />
+            </PanelRow>
+          ))}
         </PanelBody>
       </InspectorControls>
 


### PR DESCRIPTION
### Summary

Fixes #354

This pull request enhances the Query block sidebar UI by displaying the Query Parameters panel before the Select Posts panel, improving the user workflow and clarity.

### Description

- The order of panels in the Query block sidebar has been updated so that the Query Parameters panel appears above the Select Posts panel.
- This adjustment enables users to configure query parameters before selecting specific posts, aligning the interface with typical user expectations.
- The Select Posts panel, which duplicates some functionality of the main editor, is now positioned after query configuration for a more logical experience.
- The `CHANGELOG.md` has been updated under the "Unreleased" section to document this enhancement.

### Steps to Test

1. Add a Query block in the editor.
2. Confirm that the Query Parameters panel is now shown before the Select Posts panel in the sidebar.
3. Verify that users can set query parameters first, followed by selecting posts directly below as intended.

### Screenshots (if applicable)

<!-- Add before/after screenshots here if relevant -->

### Additional Notes

- This change is documented in the changelog under enhancements for improved user experience.
- No breaking changes or major refactoring; only the order of sidebar panels was adjusted for usability.