### PR TITLE
Issue-240: Subquery block missing support for drag and drop

### DIFF
--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -98,7 +98,7 @@ export default function Edit({
     },
   };
 
-  const queryBlocks = select('core/block-editor').getBlocksByName('wp-curate/query');
+  const queryBlocks = select('core/block-editor').getBlocksByName('wp-curate/query', 'wp-curate/subquery');
   const {
     attributes: {
       posts = [],
@@ -211,12 +211,18 @@ export default function Edit({
       } else if (targetElement.classList.contains('wp-block-wp-curate-post')) {
         e.preventDefault();
         // Get the parent wp-query block.
-        const parent = targetElement.closest('[data-type="wp-curate/query"]') as HTMLElement;
+        const parent = targetElement.closest('[data-type="wp-curate/query"], [data-type="wp-curate/subquery"]') as HTMLElement;
         if (!parent) {
           return;
         }
+        // find all visible wp-curate-post-block children of the parent that are not inside a .wp-block-wp-curate-subquery block
         const parentChildren = parent.querySelectorAll('.wp-curate-post-block');
-        const visibleChildren = [...parentChildren].filter((el) => el.parentElement?.style?.display !== 'none');
+        const visibleChildren = [...parentChildren].filter((el) => {
+          if (el.closest('.wp-block-wp-curate-subquery')) {
+            return false;
+          }
+          return el.parentElement?.style?.display !== 'none';
+        });
 
         const targetIndex = Array.prototype.indexOf.call(visibleChildren, targetElement);
         const parentId = parent.dataset.block;
@@ -232,7 +238,8 @@ export default function Edit({
           posts: newPosts,
         });
         // Remove the post from the source query block if it's not the same as the target block.
-        const sourceParent = select('core/block-editor').getBlockParentsByBlockName(newData.clientId, 'wp-curate/query')[0];
+        const sourceParent = select('core/block-editor').getBlockParentsByBlockName(newData.clientId, ['wp-curate/query', 'wp-curate/subquery']).pop();
+        console.log('sourceParent', sourceParent);
         if (parentId !== sourceParent) {
           const sourceOldPosts = select('core/block-editor').getBlockAttributes(sourceParent)?.posts;
           const sourceNewPosts = sourceOldPosts.map(

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -308,7 +308,7 @@ export default function Edit({
             'wp-curate-post-block',
             { 'wp-curate-post-block--selected': isParentOfSelectedBlock },
             { 'wp-curate-post-block--backfill': !selected || postDeleted },
-            { 'curate-droppable': parentName === 'wp-curate/query' && moveData.postId && moveData.postId !== postId },
+            { 'curate-droppable': (parentName === 'wp-curate/query' || parentName === 'wp-curate/subquery') && moveData.postId && moveData.postId !== postId },
             { 'wp-curate-error': postDeleted },
           ),
         },

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -239,7 +239,6 @@ export default function Edit({
         });
         // Remove the post from the source query block if it's not the same as the target block.
         const sourceParent = select('core/block-editor').getBlockParentsByBlockName(newData.clientId, ['wp-curate/query', 'wp-curate/subquery']).pop();
-        console.log('sourceParent', sourceParent);
         if (parentId !== sourceParent) {
           const sourceOldPosts = select('core/block-editor').getBlockAttributes(sourceParent)?.posts;
           const sourceNewPosts = sourceOldPosts.map(

--- a/blocks/post/index.scss
+++ b/blocks/post/index.scss
@@ -8,8 +8,16 @@
     outline-offset: 0.5rem;
   }
 
-  &--backfill .block-editor-inner-blocks {
-    opacity: 0.5;
+  &--backfill > .block-editor-inner-blocks::after {
+    background: rgba(255, 255, 255, 0.5);
+    content: '';
+    height: 100%;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 1;
   }
 
   &__actions {
@@ -48,7 +56,12 @@
   text-align: center;
   top: 0;
   width: 100%;
-  z-index: 9999;
+  z-index: 5000;
+}
+
+.wp-block-post:hover .wp-block-wp-curate-subquery .wp-curate-post-block.curate-droppable::after,
+.wp-curate-post-block.curate-droppable:hover .wp-block-wp-curate-subquery .wp-curate-post-block.curate-droppable::after {
+  z-index: 6000;
 }
 
 .wp-curate-error::after {
@@ -60,6 +73,11 @@
   right: 0;
   top: 0;
   z-index: 2;
+}
+
+.wp-curate-post-block__actions {
+  position: relative;
+  z-index: 3;
 }
 
 @container wp-curate-block (width < 335px) {

--- a/blocks/post/index.scss
+++ b/blocks/post/index.scss
@@ -56,12 +56,7 @@
   text-align: center;
   top: 0;
   width: 100%;
-  z-index: 5000;
-}
-
-.wp-block-post:hover .wp-block-wp-curate-subquery .wp-curate-post-block.curate-droppable::after,
-.wp-curate-post-block.curate-droppable:hover .wp-block-wp-curate-subquery .wp-curate-post-block.curate-droppable::after {
-  z-index: 6000;
+  z-index: 1;
 }
 
 .wp-curate-error::after {

--- a/blocks/subquery/index.scss
+++ b/blocks/subquery/index.scss
@@ -3,9 +3,10 @@
  */
 
 .wp-block-wp-curate-subquery {
+  background: #fff;
   border: 1px dotted #ccc;
-  opacity: 1;
   padding: 2px;
+  z-index: 4;
 
   p.zero-posts {
     font-size: 0.8em;
@@ -13,3 +14,4 @@
     margin: 1em 0;
   }
 }
+


### PR DESCRIPTION
### Summary

Fixes #240

### Description

This pull request addresses an issue where the Move Post button is available within a Subquery block, but it is not possible to move the post within a Subquery—only to positions in the parent Query block. This resolves the missing support for drag and drop within the Subquery block.

### Steps To Reproduce

1. Create a new Query block with a nested Subquery block.
2. Pin a post within the Subquery block.
3. Attempt to Move Post to a new position. Only positions in the Query block are available.

### Additional Information

Example code for creating Query with Subquery:

```
<!-- wp:wp-curate/query {"postTypes":["post"],"posts":[null,null,null,null,null]} -->
<div class="wp-block-wp-curate-query"><!-- wp:post-template -->
<!-- wp:wp-curate/post -->
<div class="wp-block-wp-curate-post"><!-- wp:post-title {"isLink":true} /-->

<!-- wp:wp-curate/subquery {"numberOfPosts":2,"postTypes":[{"name":"Post","slug":"post"}],"posts":[null,null],"terms":{"category":[],"post_tag":[]},"uniqueId":"87552371-c7f9-4175-9105-d5ab61240864"} -->
<div class="wp-block-wp-curate-subquery"><!-- wp:post-template -->
<!-- wp:wp-curate/post -->
<div class="wp-block-wp-curate-post"><!-- wp:post-title {"level":3,"isLink":true} /--></div>
<!-- /wp:wp-curate/post -->
<!-- /wp:post-template --></div>
<!-- /wp:wp-curate/subquery --></div>
<!-- /wp:wp-curate/post -->
<!-- /wp:post-template --></div>
<!-- /wp:wp-curate/query -->
```
