### PR TITLE
Pass resolved post IDs through context

### DIFF
--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -15,6 +15,7 @@
   ],
   "providesContext": {
     "query": "query",
+    "allPostIds": "allPostIds",
     "displayLayout": "displayLayout",
     "heading": "heading",
     "curation": "curation",

--- a/blocks/query/types.ts
+++ b/blocks/query/types.ts
@@ -36,6 +36,7 @@ interface EditProps {
   setAttributes: (attributes: any) => void;
   context: {
     postId: number;
+    allPostIds?: number[];
     query: {
       include?: string;
     };

--- a/blocks/subquery/block.json
+++ b/blocks/subquery/block.json
@@ -14,6 +14,7 @@
         "file:style-index.css"
     ],
     "usesContext": [
+        "allPostIds",
         "query",
         "postId"
     ],

--- a/blocks/subquery/edit.tsx
+++ b/blocks/subquery/edit.tsx
@@ -72,13 +72,17 @@ export default function Edit({
   setAttributes,
   context: {
     postId,
+    allPostIds = [],
     query: {
       include = '',
     } = {},
   },
 }: EditProps) {
-  const queryInclude = include.split(',').map((id: string) => parseInt(id, 10));
-  const index = queryInclude.findIndex((id: number) => id === postId);
+  // Use allPostIds context if available; fall back to query.include for backwards compatibility.
+  const queryPostIds = allPostIds.length > 0
+    ? allPostIds
+    : include.split(',').map((id: string) => parseInt(id, 10));
+  const index = queryPostIds.findIndex((id: number) => id === postId);
   const isFirstPost = index === 0;
 
   const {

--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -199,19 +199,25 @@ export function mainDedupe() {
     recursivelyFindBlocksByName(queryBlock, ['wp-curate/post', 'core/post-template'], curateableBlocks);
     const postBlockCount = curateableBlocks.filter((block) => block.name === 'wp-curate/post').length;
 
+    // Track all resolved post IDs to set as allPostIds context on the query block.
+    const resolvedPostIds: Array<number | undefined> = [];
+
     curateableBlocks.forEach((curateableBlock) => {
       if (curateableBlock.name === 'wp-curate/post') {
+        const postId = allPostIds.shift() || 0;
+        resolvedPostIds.push(postId);
         // Update each post block with the correct post id.
         // @ts-ignore
         dispatch(blockEditorStore).updateBlockAttributes(
           curateableBlock.clientId,
           {
-            postId: allPostIds.shift() || 0,
+            postId,
           },
         );
       } else if (curateableBlock.name === 'core/post-template') {
         // Update the query block with the new query.
         const templateIds = allPostIds.splice(0, numberOfPosts - postBlockCount);
+        resolvedPostIds.push(...templateIds);
         // @ts-ignore
         dispatch(blockEditorStore).updateBlockAttributes(
           queryBlock.clientId,
@@ -230,6 +236,16 @@ export function mainDedupe() {
         );
       }
     });
+
+    // Set allPostIds on the query block so descendants (e.g., wp-curate/subquery)
+    // can determine post position via context without relying on query.include.
+    // @ts-ignore
+    dispatch(blockEditorStore).updateBlockAttributes(
+      queryBlock.clientId,
+      {
+        allPostIds: resolvedPostIds.filter(Boolean), // Filter out falsy values (0, undefined).
+      },
+    );
   });
 
   running = false;


### PR DESCRIPTION
When using the subquery block, if there is no ancestor `core/post-template` block, subquery posts don't receive post IDs. The same applies to a subquery with an inner `core/post-template`.

> `wp-curate/subquery` determines whether to render via an `isFirstPost` check that compares its postId against the parent query's post list. Previously it read this from `query.include`, which only contains the subset of IDs assigned to `core/post-template`. For layouts where `wp-curate/post` is a direct child of the query (no `core/post-template`), `query.include` was never set, so the subquery never rendered. For mixed layouts (direct post blocks + template), the direct post's ID wasn't in `query.include` either.

The fix is to add `allPostIds` context to carry all resolved post IDs, decoupled from the post-template-specific `query.include`.