### PR TITLE
Issue 408: Change the title of the query block to avoid confusion with WP core query block

### DIFF
--- a/blocks/query/block.json
+++ b/blocks/query/block.json
@@ -3,7 +3,7 @@
   "apiVersion": 2,
   "name": "wp-curate/query",
   "version": "0.1.0",
-  "title": "Query",
+  "title": "Curatable Query",
   "category": "theme",
   "icon": "filter",
   "description": "Custom queries for WP Curate",


### PR DESCRIPTION
Fixes #408 