### PR TITLE
Adds "edit" and "view" post buttons to the post block

### DIFF
--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -312,6 +312,7 @@ export default function Edit({
       <BlockControls>
         <ToolbarGroup>
           <ToolbarButton
+            disabled={!postId}
             icon={pencil}
             label={__('Edit post in a new tab', 'wp-curate')}
             onClick={() => {
@@ -320,9 +321,11 @@ export default function Edit({
           />
           <ToolbarButton
             icon={seen}
-            label={__('View Post in a new tab', 'wp-curate')}
+            label={__('View post in a new tab', 'wp-curate')}
             onClick={() => {
-              window.open(postObj?.link, '_blank');
+              if (postObj?.link) {
+                window.open(postObj?.link, '_blank');
+              }
             }}
           />
         </ToolbarGroup>

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -3,11 +3,21 @@ import classnames from 'classnames';
 import type { WP_REST_API_Post as WpRestApiPost } from 'wp-types'; // eslint-disable-line camelcase
 
 // @ts-expect-error BlockContextProvider not available in types yet.
-import { BlockContextProvider, BlockControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+  BlockContextProvider,
+  BlockControls,
+  InnerBlocks,
+  useBlockProps,
+} from '@wordpress/block-editor';
 import { PostPicker, usePostById } from '@alleyinteractive/block-editor-tools';
 import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Button, Notice, ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import {
+  Button,
+  Notice,
+  ToolbarGroup,
+  ToolbarButton,
+} from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { pencil, seen } from '@wordpress/icons';
 

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import classnames from 'classnames';
 import type { WP_REST_API_Post as WpRestApiPost } from 'wp-types'; // eslint-disable-line camelcase
 
-// @ts-expect-error BlockContextProvider not available in types yet.
 import {
+  // @ts-expect-error BlockContextProvider not available in types yet.
   BlockContextProvider,
   BlockControls,
   InnerBlocks,

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -3,12 +3,13 @@ import classnames from 'classnames';
 import type { WP_REST_API_Post as WpRestApiPost } from 'wp-types'; // eslint-disable-line camelcase
 
 // @ts-expect-error BlockContextProvider not available in types yet.
-import { InnerBlocks, useBlockProps, BlockContextProvider } from '@wordpress/block-editor';
+import { BlockContextProvider, BlockControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { PostPicker, usePostById } from '@alleyinteractive/block-editor-tools';
 import { dispatch, select, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Button, Notice } from '@wordpress/components';
+import { Button, Notice, ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
+import { pencil, seen } from '@wordpress/icons';
 
 import type { Block } from '../../types/block';
 import NoRender from './norender';
@@ -308,6 +309,25 @@ export default function Edit({
         },
       )}
     >
+      <BlockControls>
+        <ToolbarGroup>
+          <ToolbarButton
+            icon={pencil}
+            label={__('Edit post in a new tab', 'wp-curate')}
+            onClick={() => {
+              window.open(`/wp-admin/post.php?post=${postId}&action=edit`, '_blank');
+            }}
+          />
+          <ToolbarButton
+            icon={seen}
+            label={__('View Post in a new tab', 'wp-curate')}
+            onClick={() => {
+              window.open(postObj?.link, '_blank');
+            }}
+          />
+        </ToolbarGroup>
+      </BlockControls>
+
       {typeof postObj === 'object' && postObj !== null && 'status' in postObj && postObj.status === 'future' ? (
         <Notice
           status="warning"

--- a/blocks/post/edit.tsx
+++ b/blocks/post/edit.tsx
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { pencil, seen } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 
 import type { Block } from '../../types/block';
 import NoRender from './norender';
@@ -326,7 +327,11 @@ export default function Edit({
             icon={pencil}
             label={__('Edit post in a new tab', 'wp-curate')}
             onClick={() => {
-              window.open(`/wp-admin/post.php?post=${postId}&action=edit`, '_blank');
+              const editUrl = addQueryArgs('post.php', {
+                post: postId,
+                action: 'edit',
+              });
+              window.open(editUrl, '_blank');
             }}
           />
           <ToolbarButton


### PR DESCRIPTION
This is a helpful addition that we on Camp FAM deemed as missing.
- Adds two new toolbar buttons to the post block's toolbar
  - Edit post, opens in new tab
  - View post, opens in new tab