### PR TITLE
FAM-3249: NPM Vulnerabilities

### DIFF
--- a/blocks/subquery/edit.tsx
+++ b/blocks/subquery/edit.tsx
@@ -6,10 +6,8 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { useSelect, select } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
-
 import apiFetch from '@wordpress/api-fetch';
 
-type TemplateItem = [string, Record<string, unknown>?, TemplateItem[]?];
 import { v4 as uuid } from 'uuid'; // eslint-disable-line import/no-unresolved
 
 import type {
@@ -25,6 +23,8 @@ import queryBlockPostFetcher from '../../services/queryBlockPostFetcher';
 
 import QueryControls from '../../components/QueryControls';
 import './index.scss';
+
+type TemplateItem = [string, Record<string, unknown>?, TemplateItem[]?];
 
 interface PostTypeOrTerm {
   name: string;

--- a/blocks/subquery/edit.tsx
+++ b/blocks/subquery/edit.tsx
@@ -7,8 +7,9 @@ import { useSelect, select } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
-import { Template } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
+
+type TemplateItem = [string, Record<string, unknown>?, TemplateItem[]?];
 import { v4 as uuid } from 'uuid'; // eslint-disable-line import/no-unresolved
 
 import type {
@@ -291,7 +292,7 @@ export default function Edit({
     }
   }, [isFirstPost, manualPosts, numberOfPosts, setAttributes]);
 
-  const TEMPLATE: Template[] = [
+  const TEMPLATE: TemplateItem[] = [
     [
       'core/post-template',
       {},

--- a/components/QueryPlaceholder/index.tsx
+++ b/components/QueryPlaceholder/index.tsx
@@ -5,8 +5,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
   createBlocksFromInnerBlocksTemplate,
   store as blocksStore,
+  Block,
   BlockVariation,
-  InnerBlockTemplate,
+  BlockTypeIconDescriptor,
 } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
 import {
@@ -15,7 +16,7 @@ import {
   __experimentalBlockVariationPicker as BlockVariationPicker,
   useBlockProps,
 } from '@wordpress/block-editor';
-import { Button, Placeholder } from '@wordpress/components';
+import { Button, Placeholder, type IconType } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,7 +28,7 @@ import { useBlockPatterns } from '../PatternSelectionModal';
 interface QueryVariationPickerProps {
   clientId: string;
   attributes: Record<string, any>;
-  icon: string | { src: string; foreground: string; background: string } | undefined;
+  icon: IconType | undefined;
   label: string | undefined;
 }
 
@@ -51,7 +52,7 @@ function QueryVariationPicker({
             replaceInnerBlocks(
               clientId,
               createBlocksFromInnerBlocksTemplate(
-                variation.innerBlocks as InnerBlockTemplate[],
+                variation.innerBlocks as Array<Block | [string, Record<string, unknown>?, Array<unknown>?]>,
               ),
               false,
             );
@@ -79,7 +80,6 @@ export default function QueryPlaceholder({
 
   const { blockType, activeBlockVariation } = useSelect(
     (select) => {
-      // @ts-expect-error
       const { getActiveBlockVariation, getBlockType } = select(blocksStore);
       return {
         blockType: getBlockType(name),
@@ -92,9 +92,11 @@ export default function QueryPlaceholder({
     [name, attributes],
   );
   const hasPatterns = !!useBlockPatterns(clientId, attributes).length;
-  const icon = activeBlockVariation?.icon?.src
+  const icon = (
+    (activeBlockVariation?.icon as BlockTypeIconDescriptor | undefined)?.src
     || activeBlockVariation?.icon
-    || blockType?.icon?.src;
+    || blockType?.icon?.src
+  ) as IconType | undefined;
   const label = activeBlockVariation?.title || blockType?.title;
   const blockProps = useBlockProps();
 

--- a/components/QueryPlaceholder/index.tsx
+++ b/components/QueryPlaceholder/index.tsx
@@ -52,7 +52,9 @@ function QueryVariationPicker({
             replaceInnerBlocks(
               clientId,
               createBlocksFromInnerBlocksTemplate(
-                variation.innerBlocks as Array<Block | [string, Record<string, unknown>?, Array<unknown>?]>,
+                variation.innerBlocks as Array<
+                Block | [string, Record<string, unknown>?, Array<unknown>?]
+                >,
               ),
               false,
             );

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,18 +345,18 @@
       }
     },
     "node_modules/@ariakit/core": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.16.tgz",
-      "integrity": "sha512-nPJ0Be8d5ZvRApYGqdLMuYUjP7ktkPmTPOXyZFw+0Illk8LKgF3Q74ctVGuoQurJNDsANXcewzlyXK4vyIAGTA==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
+      "integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
       "license": "MIT"
     },
     "node_modules/@ariakit/react": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.19.tgz",
-      "integrity": "sha512-n6q8leSQWXMk4vhcZlpnj8cIlAY0n+1bvVTwHvaVfmec4LjW49MFKkJRZd1AiV+SE73nkxPwSL3IbaS4p1aRxQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
+      "integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-core": "0.4.19"
+        "@ariakit/react-core": "0.4.26"
       },
       "funding": {
         "type": "opencollective",
@@ -368,27 +368,40 @@
       }
     },
     "node_modules/@ariakit/react-core": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.19.tgz",
-      "integrity": "sha512-Aj+fu4pMyPXtlBghI+E7KSWItqJkbAqEhut3DlsFAjK9fQdHE+e1tQJG1PtnoEdD9BExkJWQ6R4M5a9HkEhqPA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
+      "integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
       "license": "MIT",
       "dependencies": {
-        "@ariakit/core": "0.4.16",
+        "@ariakit/core": "0.4.20",
         "@floating-ui/dom": "^1.0.0",
-        "use-sync-external-store": "^1.2.0"
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@arraypress/waveform-player": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.2.1.tgz",
+      "integrity": "sha512-PsgOZStUN+1GnY0tujbwk2PYE3HMT/Vl3wEvunqH16hIJWzisf8GEngy5EbswTAjQ1aV3Tk4XBkAskc8eslY1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/arraypress"
+      }
+    },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -457,13 +470,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -583,28 +596,28 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -627,9 +640,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -744,12 +757,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1575,16 +1588,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-      "integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.5"
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2331,40 +2344,40 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2372,9 +2385,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2382,6 +2395,79 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.8",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -2538,6 +2624,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+      "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
       "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2886,22 +2978,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -2918,9 +3010,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -4409,9 +4501,9 @@
       "license": "MIT"
     },
     "node_modules/@preact/signals": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.2.tgz",
-      "integrity": "sha512-naxcJgUJ6BTOROJ7C3QML7KvwKwCXQJYTc5L/b0eEsdYgPB6SxwoQ1vDGcS0Q7GVjAenVq/tXrybVdFShHYZWg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-core": "^1.7.0"
@@ -4425,9 +4517,9 @@
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
-      "integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
+      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -5468,10 +5560,93 @@
       "integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
       "license": "MIT"
     },
+    "node_modules/@tanstack/history": {
+      "version": "1.161.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
+      "integrity": "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.169.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.169.2.tgz",
+      "integrity": "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.161.6",
+        "@tanstack/react-store": "^0.9.3",
+        "@tanstack/router-core": "1.169.2",
+        "isbot": "^5.1.22"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+      "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.9.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.169.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.169.2.tgz",
+      "integrity": "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.161.6",
+        "cookie-es": "^3.0.0",
+        "seroval": "^1.5.4",
+        "seroval-plugins": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5944,15 +6119,6 @@
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/simple-peer": {
-      "version": "9.11.9",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.9.tgz",
-      "integrity": "sha512-6Gdl7TSS5oh9nuwKD4Pl8cSmaxWycYeZz9HLnJBNvIwWjZuGVsmHe9RwW3+9RxfhC1aIR9Z83DvaJoMw6rhkbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
@@ -7758,13 +7924,13 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.34.0.tgz",
-      "integrity": "sha512-l4/Q1nnLMi1nQJWl4y3Rdr9zQnxYgGqL0ZJwz1vOI8qqSO2Uug8wVCrVIsKIuUQHuD+ya/Q5hqQIedXKAdTvsQ==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.45.0.tgz",
+      "integrity": "sha512-KOgdBsZP34nAi+UfrhIAZDt2I1ZDb3DXAgIeQk7QxTIc9OlQKMNfrYwPG0jidgfKwmjFxh8vV8HbZcBzTD29Rw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0"
+        "@wordpress/dom-ready": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7772,29 +7938,165 @@
       }
     },
     "node_modules/@wordpress/admin-ui": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-1.2.0.tgz",
-      "integrity": "sha512-6+sxKyjjr0CacE7vFD2+vt8qoYR8hqwZf5Sxg5k3uJuXnmYvafqz8vILGg6bYMgOCTT8wy/5MexWijQ6S2le3Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.0.0.tgz",
+      "integrity": "sha512-ZX6qExEPkdVzkv8gSsfU1NJU9EXdNbWCaPfck1Qo2bMcJWhb1n4zoITkfT+zAPqj3N/Fd2q8a8NOYxh2e/7fDw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/element": "^6.34.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/route": "^0.11.0",
+        "@wordpress/ui": "^0.12.0",
         "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/admin-ui/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/admin-ui/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.34.0.tgz",
-      "integrity": "sha512-A/q260VbsEP+oo0LzbQJwZ43P3cOl0FYhcO8WBpTGdNN/TYEO12shtjYZZOP6lOnFLkyAMrPKoAGrWS/V6Nq7Q==",
+      "version": "7.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.45.0.tgz",
+      "integrity": "sha512-qAx9X8B6P6eQ/XkAnQaqnkMinBTnc+qPSQEttkaUO3QQOvMeG6oWdxnjhL846z8jw6d/xcS7V89xej4P9/+BUw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/url": "^4.34.0"
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/url": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7802,9 +8104,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.34.0.tgz",
-      "integrity": "sha512-qSF/FUYz8msmNYokIFIr2VYUHmf2Xqmed1Sk8g4Zz+Mg1EMyzd1e74WmKHD6MVAqwhBgfwrXGcBH467FsnsMCQ==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.45.0.tgz",
+      "integrity": "sha512-BJAdQOVqMC7t5cTWxD7Q8P+EWu3JopXD/yaf0Qc6tuFzihngIDvV9Ck03jGY4uXJVeO5SXNqARmU1JFn8YHNcA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8005,9 +8307,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.34.0.tgz",
-      "integrity": "sha512-Y2yr2WTJcVs47jNPa5PcThpY1/2OoZKRum7up7HJQgA0P50xznxIf3u5J6IsUvHNWT7QXkyvB5hXhCaFIySc/Q==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.45.0.tgz",
+      "integrity": "sha512-B/3pz4aF/0lTdn7uZd6PXS5FEtBXeVS9/CLm9ECE4dtyqKPIvpMcDcLdTv4QfQeu7BoObV1KIpGIbrflyJvcQg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8015,48 +8317,49 @@
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.7.0.tgz",
-      "integrity": "sha512-jbeWyRU93eUQA2fqgpFNS2eD57TmrJZh4EGg5kfZYfjaU3t8fdg4AwLvzmTfYyS174Pkf/dHzpRPWEpWLI67mw==",
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.18.0.tgz",
+      "integrity": "sha512-g1sMgapiMonuDenMK9HC6klS94SrmUsZafsd7iCI2txlZxml6QKPHIVfpk+5WW9xowEAQIteZclNflHdeYG8vA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@emotion/react": "^11.7.1",
-        "@emotion/styled": "^11.6.0",
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/block-serialization-default-parser": "^5.34.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/commands": "^1.34.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/date": "^5.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/dom": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/escape-html": "^3.34.0",
-        "@wordpress/global-styles-engine": "^1.1.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/is-shallow-equal": "^5.34.0",
-        "@wordpress/keyboard-shortcuts": "^5.34.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/preferences": "^4.34.0",
-        "@wordpress/priority-queue": "^3.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/rich-text": "^7.34.0",
-        "@wordpress/style-engine": "^2.34.0",
-        "@wordpress/token-list": "^3.34.0",
-        "@wordpress/upload-media": "^0.19.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/warning": "^3.34.0",
-        "@wordpress/wordcount": "^4.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/block-serialization-default-parser": "^5.45.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/commands": "^1.45.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/global-styles-engine": "^1.12.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/image-cropper": "^1.9.0",
+        "@wordpress/interactivity": "^6.45.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keyboard-shortcuts": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/priority-queue": "^3.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/style-engine": "^2.45.0",
+        "@wordpress/token-list": "^3.45.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/upload-media": "^0.30.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "@wordpress/wordcount": "^4.45.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -8081,66 +8384,186 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+    "node_modules/@wordpress/block-editor/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/block-editor/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/block-library": {
-      "version": "9.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.34.0.tgz",
-      "integrity": "sha512-/vytv+G6QJcdgStsOPNGxsjcH+XU8aG6DU/58DtYrslMXEVRpkG95oaESaRfsmlDGwujWBkuQ+yfbHMRg6Q7gQ==",
+      "version": "9.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.45.0.tgz",
+      "integrity": "sha512-1/OipWced7itCU+2miVgMpsHIiAxxe664F5EJLZUeei7VDC4x3mFLR7pPK3xcnEJw2hf2AmLhu1F7RROqIZ7EA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/autop": "^4.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/date": "^5.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/dom": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/escape-html": "^3.34.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/interactivity": "^6.34.0",
-        "@wordpress/interactivity-router": "^2.34.0",
-        "@wordpress/keyboard-shortcuts": "^5.34.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/latex-to-mathml": "^1.2.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/patterns": "^2.34.0",
-        "@wordpress/primitives": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/reusable-blocks": "^5.34.0",
-        "@wordpress/rich-text": "^7.34.0",
-        "@wordpress/server-side-render": "^6.10.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/viewport": "^6.34.0",
-        "@wordpress/wordcount": "^4.34.0",
+        "@arraypress/waveform-player": "1.2.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/autop": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/interactivity": "^6.45.0",
+        "@wordpress/interactivity-router": "^2.45.0",
+        "@wordpress/keyboard-shortcuts": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/latex-to-mathml": "^1.13.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/patterns": "^2.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/reusable-blocks": "^5.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/server-side-render": "^6.21.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/upload-media": "^0.30.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/viewport": "^6.45.0",
+        "@wordpress/wordcount": "^4.45.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
-        "escape-html": "^1.0.3",
         "fast-average-color": "^9.1.1",
         "fast-deep-equal": "^3.1.3",
+        "html-react-parser": "5.2.11",
         "memize": "^2.1.0",
         "remove-accents": "^0.5.0",
         "uuid": "^9.0.1"
@@ -8154,13 +8577,116 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+    "node_modules/@wordpress/block-library/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-library/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8181,9 +8707,9 @@
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.34.0.tgz",
-      "integrity": "sha512-fQeTtiyCzZWez1b3rRN6DhY7gA6UZLiQbZgiVPQH8xQ36nFPV2U3MkVDI7oHajRJ1RyBQKHcmAhA3bseHQD/2w==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.45.0.tgz",
+      "integrity": "sha512-48Pj6o9iDGf7fCprXoXD8nvDgBigrQ6uZEb+VMrcvabn59ymKHzx/Ex9O3mpp7Ft2NMJRGpO3w0mNocoDfCksA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8191,26 +8717,26 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.7.0.tgz",
-      "integrity": "sha512-XsPgPn3PKMd017S0AgzHOw6MAahYKbULh5gXjdOTFJTCFDlL6TkCcLEJYbYqY8NAVlm4OF2tF0MR4Bb1bxcrpg==",
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.18.0.tgz",
+      "integrity": "sha512-orpiOWWmG9qdacqMC4WIdHgZRJNLLmCqTLj/5HQcBAfOXjbUQcjOj6f4lZx9HS89kJ350KJOkqWVPWrZoJE9og==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/autop": "^4.34.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/block-serialization-default-parser": "^5.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/dom": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/is-shallow-equal": "^5.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/rich-text": "^7.34.0",
-        "@wordpress/shortcode": "^4.34.0",
-        "@wordpress/warning": "^3.34.0",
+        "@wordpress/autop": "^4.45.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/block-serialization-default-parser": "^5.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/shortcode": "^4.45.0",
+        "@wordpress/warning": "^3.45.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -8256,19 +8782,21 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.34.0.tgz",
-      "integrity": "sha512-ppd0y6WBJMOiQzzXS6UuqHC7G5NqsBPhhygxoeWJlfpaiKjgKxi0tMruN81uRV/ORyhYTT8U3Hz4aFSn4pi47w==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.45.0.tgz",
+      "integrity": "sha512-R71ZtwwqEkrQ/098HyiOeYq7Iu13770BroqtuTjBkNY2tWIR3WNUnMlK3UKDO70QhPtkLZaoz79AWKRCfVUTnw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/keyboard-shortcuts": "^5.34.0",
-        "@wordpress/private-apis": "^1.34.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.45.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/warning": "^3.45.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
       },
@@ -8279,6 +8807,136 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/components": {
@@ -8370,21 +9028,20 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.34.0.tgz",
-      "integrity": "sha512-gCgsU/VB8mvP9WqzOJLpd9p6ErTBC9qMhP9HQWnmW/SiYm0mhmNaknyr1viu4QYDlMeTVsCycNiP+MacUDCUzg==",
+      "version": "7.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.45.0.tgz",
+      "integrity": "sha512-/keWdRFUe7bnzh2ZtOYLexknpj0K0G56WFw7RLZehl54a9EmzjYjAODBOF9DB3c07pJuNuy7c5QgqMPi0cqLlw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/dom": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/is-shallow-equal": "^5.34.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/priority-queue": "^3.34.0",
-        "@wordpress/undo-manager": "^1.34.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/priority-queue": "^3.45.0",
+        "@wordpress/undo-manager": "^1.45.0",
         "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
       },
@@ -8397,12 +9054,12 @@
       }
     },
     "node_modules/@wordpress/compose/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8410,27 +9067,27 @@
       }
     },
     "node_modules/@wordpress/core-data": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.34.0.tgz",
-      "integrity": "sha512-7qiseCbHxqkKcwK1LKZJDOihJsU9VpJlQRQg5HZvTrI6it9l2cRpZMFpuUbeK9gf9T2AuBgfyM6BGjl0G890mw==",
+      "version": "7.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.45.0.tgz",
+      "integrity": "sha512-aXp9K7on8wKq/PlSYdZNZRFYJjK0OUUlyrBpyyQuioSfPYav76ImGf6DAI0tJ7PCZF61KmMT9KHfQMjnK4bh4g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/is-shallow-equal": "^5.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/rich-text": "^7.34.0",
-        "@wordpress/sync": "^1.34.0",
-        "@wordpress/undo-manager": "^1.34.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/warning": "^3.34.0",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/sync": "^1.45.0",
+        "@wordpress/undo-manager": "^1.45.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/warning": "^3.45.0",
         "change-case": "^4.1.2",
         "equivalent-key-map": "^0.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -8460,18 +9117,18 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.34.0.tgz",
-      "integrity": "sha512-3xk2NHweks8TLHyhTnMuIXTV2IVBCcejpGMTJeAayLoh0i/G+285EMz7O1t6fIu3u5uXCd/vQdJ2ewLTiIqXiQ==",
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.45.0.tgz",
+      "integrity": "sha512-OR/uMpcEbCh1aBkbzateXffNrL829M+N92qtuD+Gt08Mey129WIEVR9kBC2Tf02VtXs644OKZD6cz77KlxH8XA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/is-shallow-equal": "^5.34.0",
-        "@wordpress/priority-queue": "^3.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/redux-routine": "^5.34.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/priority-queue": "^3.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/redux-routine": "^5.45.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8489,25 +9146,26 @@
       }
     },
     "node_modules/@wordpress/dataviews": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-10.2.0.tgz",
-      "integrity": "sha512-Kwt5tB4SRkyWFVVqgGNraRajNm5lACObrzLV1f2A2343dQ88cgiS5iukI9qdhzy7CiGIHN7UrQaFbpDoTtOKAA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.2.0.tgz",
+      "integrity": "sha512-jTsXH3fDEQbvtK7N/giZJtE/NdDYN/LOlf6dkbfh89GyJmvwuikQZjpX10DexqOjc8AcNPUd1hU2b1sL8d99HA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ariakit/react": "^0.4.15",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/date": "^5.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/primitives": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/warning": "^3.34.0",
+        "@ariakit/react": "^0.4.21",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/warning": "^3.45.0",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
         "date-fns": "^4.1.0",
@@ -8524,13 +9182,126 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+    "node_modules/@wordpress/dataviews/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8547,13 +9318,27 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/@wordpress/dataviews/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/date": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.34.0.tgz",
-      "integrity": "sha512-0HbuRIL8b1KtpAU1ANG58iY07p9m0+jGUDpJCvJlPOQiCP0nDDLws9C5vTPrRiJnosxj6elyHtyt4LQnHAFJRA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.45.0.tgz",
+      "integrity": "sha512-34v3hCxn68kYzWs8bhuAt8cfMxdFX9ukKn3a3FB+tAJXpxafnPCcZoWfJHn4I8hepCbreFrf3UiGdA+id2kQ4A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.34.0",
+        "@wordpress/deprecated": "^4.45.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -8587,12 +9372,12 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.34.0.tgz",
-      "integrity": "sha512-SuQX1CX97dBVPmN33zdzdjkBHajkOpr1WUdLfiP5aR8xS9CAlyMJgfYygBxFZeMKmsbBYENDVJtrulw4lPvkKw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.45.0.tgz",
+      "integrity": "sha512-qer/fk/lgmmisb8/hj1xZtsbJbZhCoOblhyxI2k7RRul7rQDdk+fm28LJYV+eIF0ldSVX30f4dmz1pvcVHQEEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.34.0"
+        "@wordpress/hooks": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8600,12 +9385,12 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.34.0.tgz",
-      "integrity": "sha512-W2gk4kkjhEHBLg/6nrJJ4QfvRguuzAx83S8UXS4tYtcYKh5vCzzcDPv8hN3cMS75R5nZBBzHgNfquS5iDhSXOA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.45.0.tgz",
+      "integrity": "sha512-6RObr/KEZS1FnZwpcDAsKlJ3qw2KLF5+A/LsxlM9fSWDGSO05CEaTp+VmWgx9pwjQWbPEa7N73ijEy8cCNSZWA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.34.0"
+        "@wordpress/deprecated": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8613,9 +9398,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.34.0.tgz",
-      "integrity": "sha512-LclbzuGRtDkF/NrygvnjtO+hcQsnq/iC+iEa78KvHJXQB8daWvrImgqhsD99K53e8AeUwtUFPFwLac5Co14jOg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.45.0.tgz",
+      "integrity": "sha512-0lFImpg9DGXcGCDQePdoU8haz7QYsKOFXUMTpRvi/Te38LFXzgZtOUBQbY8fRBlLxrgrj4FsAIc7bzdLn73wNQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8645,42 +9430,43 @@
       }
     },
     "node_modules/@wordpress/edit-post": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.34.0.tgz",
-      "integrity": "sha512-SfbQWe/oKzl2JlWiSZFylMVO1xhx9KjujOSfhaLQ3utsNBlQLWd2PwqSCA1y2fVnDWxVw1n30z9NIBaGaPGs+g==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-8.45.0.tgz",
+      "integrity": "sha512-WPTr/I6klw57JNkx353gxPvdPfo/ai2QYi6SEoTOKk81GKfHf168NvUCdjjTkWsqLsaLRxyY25LpO1T2q8b+8Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/admin-ui": "^1.2.0",
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/block-library": "^9.34.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/commands": "^1.34.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/dom": "^4.34.0",
-        "@wordpress/editor": "^14.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/global-styles-engine": "^1.1.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/keyboard-shortcuts": "^5.34.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/plugins": "^7.34.0",
-        "@wordpress/preferences": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/viewport": "^6.34.0",
-        "@wordpress/warning": "^3.34.0",
-        "@wordpress/widgets": "^4.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/admin-ui": "^2.0.0",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/block-library": "^9.45.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/commands": "^1.45.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/editor": "^14.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/global-styles-engine": "^1.12.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/keyboard-shortcuts": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/plugins": "^7.45.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/viewport": "^6.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "@wordpress/widgets": "^4.45.0",
         "clsx": "^2.1.1",
         "memize": "^2.1.0"
       },
@@ -8693,68 +9479,192 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+    "node_modules/@wordpress/edit-post/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/edit-post/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/edit-post/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/editor": {
-      "version": "14.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.34.0.tgz",
-      "integrity": "sha512-AYfJ/6VbEP+5qTloo23b2NNzAp2/grwDUmjDSeFMUvA0PT2GCu+6LBMxb+y3rSSz83jVmP5hhI8TBAS7rNn8QQ==",
+      "version": "14.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.45.0.tgz",
+      "integrity": "sha512-rhKa5cVv+tyb5+mUHjJvrN9ip3V1INTGenSyoCgRJ7suXtfOuGh6K7mCPpCDG4wTQrlEq2BmyWEnTfKeggJAyQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@floating-ui/react-dom": "2.0.8",
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/commands": "^1.34.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/dataviews": "^10.2.0",
-        "@wordpress/date": "^5.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/dom": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/fields": "^0.26.0",
-        "@wordpress/global-styles-engine": "^1.1.0",
-        "@wordpress/global-styles-ui": "^1.1.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/interface": "^9.19.0",
-        "@wordpress/keyboard-shortcuts": "^5.34.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/media-utils": "^5.34.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/patterns": "^2.34.0",
-        "@wordpress/plugins": "^7.34.0",
-        "@wordpress/preferences": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/reusable-blocks": "^5.34.0",
-        "@wordpress/rich-text": "^7.34.0",
-        "@wordpress/server-side-render": "^6.10.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/warning": "^3.34.0",
-        "@wordpress/wordcount": "^4.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/block-serialization-default-parser": "^5.45.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/commands": "^1.45.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/fields": "^0.37.0",
+        "@wordpress/global-styles-engine": "^1.12.0",
+        "@wordpress/global-styles-ui": "^1.12.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/interface": "^9.30.0",
+        "@wordpress/keyboard-shortcuts": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/media-editor": "^0.8.0",
+        "@wordpress/media-fields": "^0.10.0",
+        "@wordpress/media-utils": "^5.45.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/patterns": "^2.45.0",
+        "@wordpress/plugins": "^7.45.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/reusable-blocks": "^5.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/server-side-render": "^6.21.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/upload-media": "^0.30.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/views": "^1.12.0",
+        "@wordpress/warning": "^3.45.0",
+        "@wordpress/wordcount": "^4.45.0",
         "change-case": "^4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "^2.1.1",
+        "colord": "^2.7.0",
         "date-fns": "^3.6.0",
+        "diff": "^4.0.2",
         "fast-deep-equal": "^3.1.3",
         "memize": "^2.1.0",
         "react-autosize-textarea": "^7.1.0",
@@ -8770,13 +9680,116 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+    "node_modules/@wordpress/editor/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8797,14 +9810,14 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.34.0.tgz",
-      "integrity": "sha512-WoCBhGa7fTd9NB0B1XS+hF64vmglI90tEskQxxfqtgby1IiLj7TjG+zyVeW1UdrKja3zSAhZTqZc1wjpEtbcoQ==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.45.0.tgz",
+      "integrity": "sha512-WFrGNPEnj8uE+XhFW9NVbxvqraYpConaEokLv9IszFYVfyg8juXSQcHOAfEnxjC08HBPfVcayr2igu/XUgGOAw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.34.0",
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/escape-html": "^3.45.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8816,13 +9829,13 @@
       }
     },
     "node_modules/@wordpress/element/node_modules/@types/react": {
-      "version": "18.3.26",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
-      "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@wordpress/element/node_modules/@types/react-dom": {
@@ -8857,9 +9870,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.34.0.tgz",
-      "integrity": "sha512-uDkh9w970Lnh43GTw/8csw0BkWY08tzYo2gqIF1I26N7YnpwRbVnv1Swet8PFvv8YDxpfejWBFfA7so4nciKfw==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.45.0.tgz",
+      "integrity": "sha512-IW4mnA+65XKhABuBkwrQNAlbq97luC6ZIBfdSq0Tkq+AFPqE1lJTMlLo7iBkTpsHsBLyznViPXultq40fz8L7w==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9213,35 +10226,37 @@
       }
     },
     "node_modules/@wordpress/fields": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.26.0.tgz",
-      "integrity": "sha512-lV3Va+gyqw+Kig+fLHwZnvU/JssjEM0ZECSqgWwy1c5QPmjhwVt/BAzoL+XN7Hq+H7HBJghmBGYAK46QnJ7+DA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/fields/-/fields-0.37.0.tgz",
+      "integrity": "sha512-entmTGKQZMSTZIM8j5jdnFzzl6McusfGFScDXASqSZCkMeiTe1BmlpoCIX5MkOTLRnW9hsf1pvOxM6ou8QKACQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/dataviews": "^10.2.0",
-        "@wordpress/date": "^5.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/media-utils": "^5.34.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/patterns": "^2.34.0",
-        "@wordpress/primitives": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/router": "^1.34.0",
-        "@wordpress/url": "^4.34.0",
-        "@wordpress/warning": "^3.34.0",
+        "@react-spring/web": "^9.4.5",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/media-utils": "^5.45.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/patterns": "^2.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/router": "^1.45.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "@wordpress/wordcount": "^4.45.0",
         "change-case": "4.1.2",
         "client-zip": "^2.4.5",
         "clsx": "2.1.1",
@@ -9255,16 +10270,146 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.1.0.tgz",
-      "integrity": "sha512-YQd2G17LLACAB2qg4JtUJM928MbR42lIThO5LaLA/O0QsjQX2RCRIr40wWRtFk0shyO12EyOXbkMMCR191vjOg==",
+    "node_modules/@wordpress/fields/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/fields/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/fields/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/style-engine": "^2.34.0",
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/fields/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/fields/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/fields/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/global-styles-engine": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.12.0.tgz",
+      "integrity": "sha512-4RWpN50E9OEhd3nBP9CXOc1gybSCFulDzqHQLHkNS9iCPhpn7J3tE32XcCVVMHis9atO+PAktVKkWiPzQf+0Qw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/style-engine": "^2.45.0",
         "colord": "^2.9.2",
         "deepmerge": "^4.3.0",
         "fast-deep-equal": "^3.1.3",
@@ -9277,28 +10422,28 @@
       }
     },
     "node_modules/@wordpress/global-styles-ui": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.1.0.tgz",
-      "integrity": "sha512-cqrtm+6CHj+LqNLsbysfocZ26E1zmYnyaz5VDSRKo5i9QJ7aP5ZbK+q2lTYMXwRs8tCCM/T8P2MZUBJQwUdoHw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-ui/-/global-styles-ui-1.12.0.tgz",
+      "integrity": "sha512-HIqnO8zdaRTp/lxuCvyujT1v+lPrNAtfDvtmJNvuMXiyqmNUhOgg7F23xnhs1WzGpemToIEjc5q6s+NaH1bUKw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/date": "^5.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/global-styles-engine": "^1.1.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/keycodes": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/global-styles-engine": "^1.12.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
         "change-case": "^4.1.2",
-        "classnames": "^2.3.2",
         "clsx": "^2.1.0",
         "colord": "^2.7.0"
       },
@@ -9311,23 +10456,140 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+    "node_modules/@wordpress/global-styles-ui/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/global-styles-ui/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/hooks": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.34.0.tgz",
-      "integrity": "sha512-uZcgAMDhf6OzYCUoDqq//wYsfC7yx+XUd2av07aROn8SKTkWRfu7zweJHsOBmK0TkCx976ELoL/SZZfHPcj3aw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.45.0.tgz",
+      "integrity": "sha512-+gOlu8TdohqL1INQNxS/7CxhM4T4MuYnKietWV9zWDmNQV2ysM0SdamNk5pWERJ4w0yY9XhtMBcwR/piJtePZg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9335,9 +10597,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.34.0.tgz",
-      "integrity": "sha512-TYYNhGbHEAuVH48Q5+Muy1Bc1G32yK+4btLhkiQOtRXfa/p7f+3bUMe1/t3wgdmU1hM//wS6dsJ2wvXa9rBCeA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.45.0.tgz",
+      "integrity": "sha512-7W95xaOv4UgMSWlEmyO7YkBsUae3QlQu3GKENVH7Pt/osbJGSPInAJ1ruO4oeUwGPygWOL7b7IzRsgTNP0M/Wg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9345,13 +10607,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-      "integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.18.0.tgz",
+      "integrity": "sha512-6dYCih4wUwi7Csu4RNfHiAKkgWhpSQdl8YthvQUF59Sfsoia3RCdtd4K2l7W4f18ldFA/RXjShMjvSexWy6OyQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.34.0",
+        "@wordpress/hooks": "^4.45.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -9378,10 +10640,162 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/image-cropper": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.9.0.tgz",
+      "integrity": "sha512-cHkLNS/ePQIAAOnQy9lgaAWzLjDGYHHkziHXq/EOLN75FW0mxj6nmsHoa5N5YebKEVAeqc7UfyRNNp0Bbflsig==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "clsx": "^2.1.1",
+        "dequal": "^2.0.3",
+        "react-easy-crop": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.34.0.tgz",
-      "integrity": "sha512-0WRvm1mCulCCYCpGNIXkDFK41L9VJblnkXrOeXFV9lfePCLQN/ulAEgUSQCRbQiG/B//w8cQKUl3XFmkM3Ev1g==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.45.0.tgz",
+      "integrity": "sha512-QL/ANMn1lO+O+E/hxHtzE3yMx2mB2MxfKwN24f58HiVgKQ8ufUSYwcZfH2gLY+n9MfDoKbnvtkSpsEdL6I7y3A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
@@ -9393,13 +10807,13 @@
       }
     },
     "node_modules/@wordpress/interactivity-router": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.34.0.tgz",
-      "integrity": "sha512-j0fEqqnixg6enr3CVKIokOhvxqPdYi0oPqcvlrtD2uBB36Dm5WDa1VS5ezmugpAomzV3KF7GOJjeELGrvS1SDg==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.45.0.tgz",
+      "integrity": "sha512-oswqAE/IVedf1lzNfFSIRogeN4GAEUpQcEJBq6qhjuAUAff7pvxCW9N0HQWFRYiS4QWHLvCeKAq3RBvPrEf6MQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/interactivity": "^6.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/interactivity": "^6.45.0",
         "es-module-lexer": "^1.5.4"
       },
       "engines": {
@@ -9408,23 +10822,24 @@
       }
     },
     "node_modules/@wordpress/interface": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.19.0.tgz",
-      "integrity": "sha512-jngW8S/YPdjH62hH7fxvPaUVSO8MqcQaQW5ORoYmi0ZIbM9D1kTbfcWU6vPNzvT79wDScoQkpBFSzUZyafmZpA==",
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-9.30.0.tgz",
+      "integrity": "sha512-TNl271dsbGBrDY0FLjlQuETUbA7qDYq3KkA4vdz7CJQXSHipXvkid3V7NP1M7Y3N8asUBq/+5n+Wg3GFWZ/S1A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/admin-ui": "^1.2.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/plugins": "^7.34.0",
-        "@wordpress/preferences": "^4.34.0",
-        "@wordpress/viewport": "^6.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/admin-ui": "^2.0.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/plugins": "^7.45.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/viewport": "^6.45.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -9436,10 +10851,140 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/interface/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/interface/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/interface/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/interface/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/interface/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/interface/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.34.0.tgz",
-      "integrity": "sha512-p401k9SahwMOlmQq9DsKnfpHbax6QtE1hB6qTS/1VfhKLYy/DHc43OKafrwGB5G+rHntrsBNsO9r63DRcl4bbQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.45.0.tgz",
+      "integrity": "sha512-saamGjAuhZOiFOyznsriPGrO8GRDremImMO4q92qjQqmDqssC+FRDQnwr9D8BaedSnVvUDcriGeYBObEEnIJ2A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9760,14 +11305,14 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.34.0.tgz",
-      "integrity": "sha512-sgVHlzfBil7wY43i+htdm1Rqayt4spNeewGFsm7KlMPOw5IIvZNcNzE8dH6Ycao8YOgM3Mx1tzdjRROGXforYA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.45.0.tgz",
+      "integrity": "sha512-icOA81P50p1xe1LmK2epxmpXrKrq0BYrrUjDOaMQZbH+giZfGvMyvt47bvNVuZqg6BBzTLqZ4X8PUFcCiO6osQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/keycodes": "^4.34.0"
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/keycodes": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9778,12 +11323,12 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9846,9 +11391,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@wordpress/latex-to-mathml": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.2.0.tgz",
-      "integrity": "sha512-bOgqeIWbNY3zTfvp6X0ufHaLnG4POVDOe3n50AiFL1STb1uVOE2b+SWAnM9RtukIV92Axg1nSklFXoyZRD+iXQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.13.0.tgz",
+      "integrity": "sha512-YsGWTccjMVH3RDZGJB4Ft8+hv9RsWadLgnHia7llp0YpkB0z94UDbi7niqy5C5aKEK6MvmIlLp/nLdpuprTTmw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "temml": "^0.10.33"
@@ -9858,35 +11403,27 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/media-utils": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.34.0.tgz",
-      "integrity": "sha512-AqOvXCVRobeHsjPCIMobdQHiSYzslYB1lgjerEkRzJ6cKkzrP4t7/Lt4vDuEAiOix9Fs/Ly+XccFxVGoB2iCqg==",
+    "node_modules/@wordpress/media-editor": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-editor/-/media-editor-0.8.0.tgz",
+      "integrity": "sha512-3amhIVFe2B3Tn06QDAQqnnNurVoVGBkoON8QuD5jRxk2Gzx9f2MJdLT5M2Bp8tKploO3929tmKK6nEKLZdBdFw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/dataviews": "^10.2.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/private-apis": "^1.34.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.34.0.tgz",
-      "integrity": "sha512-uwH4vthr/rI15Xg8cvp6d18yAHAA+HiYKHLu0RsftF5bdecD1tnUGtmpb9FlO4ydVkISBSKbbPWXvt4O0uTLGg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/data": "^10.34.0"
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/interface": "^9.30.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/ui": "^0.12.0",
+        "clsx": "^2.1.1",
+        "gl-matrix": "^3.4.3"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9894,6 +11431,604 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-editor/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/media-fields": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.10.0.tgz",
+      "integrity": "sha512-D5zew8mjL3kiR1YMJ1uiO9PKk0zw7uqVH7Zn6EZJCFFHbjcMTGlIFcMtXUlBQBJgZcRUtlpnPRwi5WaoHJtKjA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/url": "^4.45.0",
+        "clsx": "2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-fields/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/media-utils": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.45.0.tgz",
+      "integrity": "sha512-XAX8mWpghNjARbBJG2h2Oq6QMYwzuW1pFPKkRP8iQQlANdx1YwC2X/f9sNDYYRkTPWaFG7yLEoLhnREVZMRysw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/media-fields": "^0.10.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/ui": "^0.12.0",
+        "@wordpress/views": "^1.12.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/media-utils/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/notices": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.45.0.tgz",
+      "integrity": "sha512-V0uRC/zMktet66jdICkr9iuZsLV2vEY/LhuWNFaJ3veIdLMBZ5EIMYwiLOGA1DagtDll0vi7/ab/xXVij7vK/Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/data": "^10.45.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
@@ -9911,26 +12046,26 @@
       }
     },
     "node_modules/@wordpress/patterns": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.34.0.tgz",
-      "integrity": "sha512-2t3e5aH/i/60dsJoXXWiXnjW6Nk2WathmW3PhSZwBB4T/lII50QGN7alANpBZC64ogaJaFjNC9gYyELlDjrICQ==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.45.0.tgz",
+      "integrity": "sha512-7aniq0ImCqvd7BhtxH89OZfyXPaht7sPlVzrXV76+Vioa8H84QBgS9bfzgv0dsgvDU1DEsmXIGY18xeKJ7XuHA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/html-entities": "^4.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/url": "^4.34.0"
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/url": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9941,19 +12076,149 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/plugins": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.34.0.tgz",
-      "integrity": "sha512-GYhDxPMgni9S9q0l3aQX8TxqQwHTytZ/X/W9YNdSgSvPRj0Kg4pcac+iLR1Obc/Mm5oxTsAZarS8itysjqFonQ==",
+    "node_modules/@wordpress/patterns/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/is-shallow-equal": "^5.34.0",
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/patterns/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/plugins": {
+      "version": "7.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.45.0.tgz",
+      "integrity": "sha512-y+hsiP7Ag/luOmrzgl5nebFDSjd1M7CjUGKWMSEVh5NzcQwhY6bZuSj1yOfVq7fFlNfvE6pB38nmh1etpPnFeA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
         "memize": "^2.0.1"
       },
       "engines": {
@@ -9963,6 +12228,136 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/plugins/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
@@ -9985,21 +12380,21 @@
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.34.0.tgz",
-      "integrity": "sha512-YWxO/llEaewLujBgluIxrn1SpeP2vmoR48DpKFx6n6NOLkS03XyyqlyuAQNsNCefV9AiUbiHxIyyGivlPbIsig==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.45.0.tgz",
+      "integrity": "sha512-ZM9W7T05NeVOLc+4WhCpFsCUb6r6BqBYvWgK7KCpMRVnvYqUDAqzh9HuuTFfiLabotOJm2Hpm8G1M+iqIEehvA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/private-apis": "^1.34.0",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/private-apis": "^1.45.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -10009,6 +12404,136 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@wordpress/prettier-config": {
@@ -10026,12 +12551,12 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.34.0.tgz",
-      "integrity": "sha512-6M/xFse9Da6oC+EZKGGOVCvbX/f5OOw539lyhugnS0sQ+NIWNvvwDh6VW1bCaWQ6uaZDUYbbQeD6Ax97NQuV+w==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.45.0.tgz",
+      "integrity": "sha512-x+i6EKUvz96EkUb2KuBTLNGm8d5+ZS0FYjUEnIhp5dtWxjMe8dJT6LS+n363vg+K28LVvjptiTAaByccnNKc9w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.34.0",
+        "@wordpress/element": "^6.45.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -10043,9 +12568,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.34.0.tgz",
-      "integrity": "sha512-6qxUP36bvSTvKkxoOhfSPmMZbSt4eCt5diQEugW9LXCuHA6lfWQ2sh1tWWzKpLD9zQCzeYIeVqA1jYHjbO929Q==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.45.0.tgz",
+      "integrity": "sha512-0sIX2PRPzo5nk252f60xpPj3/BUZxEOLcabCC7FuvQDYPGZrRyS6Dy0vDDzozZxHGuUYCT65t8ubBwXx37wXCw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -10056,9 +12581,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.34.0.tgz",
-      "integrity": "sha512-6AgwgkVZOlXu6kJpQrAtC5WiRfUfxCu/oOKMeN3m8YddJTKj8eRNO7hHfQa0TCOZi7dEEtnnmrREMb0EFIzmPQ==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.45.0.tgz",
+      "integrity": "sha512-UjhIDpoyKKUghPM0tkqd5Whsuk4kqfAfhb5VYGoEYtunDs0rB8IxgFO7hE0PhimHL74QVgaJOlprRZVRCCoQ6w==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -10066,9 +12591,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.34.0.tgz",
-      "integrity": "sha512-OYODJsho0wwCGrzEutelzBQpWHDS0quwJPGqx4TIWgoBnQtObcPyeqXDMGDJXfAFYP1KT3iE7hsU280EASxpng==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.45.0.tgz",
+      "integrity": "sha512-6ShpBns4jIBFXrYFBcKA5pnFm/kjr1SqFvLj5DwLgMV61eI3Rr9LyZwIzNR2BGg067ryxu4W172Uqjke/mZjcQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -10084,23 +12609,23 @@
       }
     },
     "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.34.0.tgz",
-      "integrity": "sha512-fZdJ3f/bMdg1MF+Wpjv6iC4bcMWuUQYANfwHbdPr0i0xNDp2Vob0bAvNPtFBkj7gO2P1TwDcvEli9YVAp3zMQQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.45.0.tgz",
+      "integrity": "sha512-TlpqOrheSRv2PnZtNdJtMDmK7lkn4ikjpIMtHiWp1lfr/bf5O92VHg0gocEL4tatu2otz7otyMzJyRkyBgBmhg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/notices": "^5.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/url": "^4.34.0"
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/notices": "^5.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/url": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -10111,20 +12636,152 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/rich-text": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.34.0.tgz",
-      "integrity": "sha512-zlzrxCFrUjG4wBrEhK7CNXc8vk5Ynq5GE/BC4dXJtk+/EgFNaFtZmusJdHnJSJx46WPeBcDjZk4W7ozAbXzaiA==",
+    "node_modules/@wordpress/reusable-blocks/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.34.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/escape-html": "^3.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/keycodes": "^4.34.0",
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/reusable-blocks/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/rich-text": {
+      "version": "7.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.45.0.tgz",
+      "integrity": "sha512-C5+JQqNzA3fiQq0hN9pQPKsjcwO/fczouHqubq3847kAUrClROqqI1GJHE34WLl1Vp+/tWQuBkIjQ/95olKteA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -10137,28 +12794,46 @@
       }
     },
     "node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-      "integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.7.0"
+        "@wordpress/i18n": "^6.18.0"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/router": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.34.0.tgz",
-      "integrity": "sha512-BBgVmuDenNLaupLpyHu+yb6gDUmjguNQw9h6Q5d0kFCU0I/3GjU5xUVo+ll50WO+nc3kFx/bDw7UPJfTteT+DQ==",
+    "node_modules/@wordpress/route": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/route/-/route-0.11.0.tgz",
+      "integrity": "sha512-3P02OKhI6yTlxHo1mLg8l8QNGsKi+e63ICP0KkaMZl5aMumfjzpZr9/fH0+uyuRdS5m2uu3BVMVa0J4QG6gMyg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/url": "^4.34.0",
+        "@tanstack/history": "^1.133.28",
+        "@tanstack/react-router": "^1.120.5",
+        "@wordpress/private-apis": "^1.45.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/router": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/router/-/router-1.45.0.tgz",
+      "integrity": "sha512-8zLDJbCQICiCq98ahNcarAEMYLxE3CP79yXL0u32BdWeOTP1GdgBtqlOwXG9CBt5xrOGIGx8la9KSfJFCxNkmA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/url": "^4.45.0",
         "history": "^5.3.0",
         "route-recognizer": "^0.3.4"
       },
@@ -11649,20 +14324,20 @@
       }
     },
     "node_modules/@wordpress/server-side-render": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.10.0.tgz",
-      "integrity": "sha512-9D2UkJ2f554XBmG5k4hSAkuf2hW5iEM+s47tWoC+BmEwtYNo/hTJ+XmcG7OgixSs9xVCXkEvI2pMancSY0tAQg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.21.0.tgz",
+      "integrity": "sha512-hhewUyFy5KKHgWjDNAUKjj0i6rBFdLKln7LlCm4rWbZiWhS1uHOOhkyO1GJiwCL+gQjZjY0QBhNGmTfDFetvEg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/deprecated": "^4.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/url": "^4.34.0"
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/url": "^4.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11673,10 +14348,140 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/server-side-render/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/server-side-render/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.34.0.tgz",
-      "integrity": "sha512-J2G7WY0qGwMDHlPH7lEaHWwCz9eoLY5KB9v2htAmSp+hCLyD/Xw2sk8Cdn77TMbyoF2G/vJxRQwJOC+tWQQAYQ==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.45.0.tgz",
+      "integrity": "sha512-lHuE3BOOV6hWieDCW0pRUk/jP+qEKjhZs/G5EAko5t7IcNmaihmBBos8RpvZDEzkK8CoH8vfoAQAmYW0xP146A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "memize": "^2.0.1"
@@ -11687,9 +14492,9 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.34.0.tgz",
-      "integrity": "sha512-GRw6+BweSE90ZOfhzS5Ny6uV6guBp7dW6OtOIlfCjiLNv8yIbBmy8kdy+nuIGjVtr49JKWWHjNYX3+gng4gHZg==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.45.0.tgz",
+      "integrity": "sha512-TQZbdLiDsQL1EATq4HKkmKCn99+l6eK3fmBpwOgXeOscQB9ta/Na64KYLoilZBuXnAelmFOXsWpz0c8ijRRniw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "change-case": "^4.1.2"
@@ -11720,44 +14525,137 @@
       }
     },
     "node_modules/@wordpress/sync": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.34.0.tgz",
-      "integrity": "sha512-utnmAuxL3CRcPJ84A4mKSRMzLqlLzxspQdFXhXypEHjSe3voKONs/jVGSBoHKyovBrdANzS2Ey8Xh7meqD8NTQ==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.45.0.tgz",
+      "integrity": "sha512-K+js/65DPrkNNVNg871C6HROm4BYt5iHY5HRBXfrErnoeXesDG9I1RrfqHu1mHn+JTn5nX1wJVlKDlCimY/B6g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/simple-peer": "^9.11.5",
-        "@wordpress/hooks": "^4.34.0",
-        "@wordpress/url": "^4.34.0",
-        "import-locals": "^2.0.0",
-        "lib0": "^0.2.42",
-        "simple-peer": "^9.11.0",
-        "y-indexeddb": "~9.0.11",
-        "y-protocols": "^1.0.5",
-        "y-webrtc": "~10.2.5",
-        "yjs": "~13.6.6"
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/undo-manager": "^1.45.0",
+        "diff": "^8.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "lib0": "0.2.99",
+        "y-protocols": "^1.0.7",
+        "yjs": "13.6.29"
       },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/sync/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@wordpress/theme": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.12.0.tgz",
+      "integrity": "sha512-AmEVO0B+kI9tsxkLnna/S+7yi+EPCMTuaPqagje7pnlXeDfykVQfeDeWJfU+QvhcqHXCySn89vvw1Ihep0rj7w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "colorjs.io": "^0.6.0",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "stylelint": "^16.8.2"
+      },
+      "peerDependenciesMeta": {
+        "stylelint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/token-list": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.34.0.tgz",
-      "integrity": "sha512-Je13FkjGNg6OcJdD3dC02c4ifi9lAIPLtBy7KsxODt7HHXYiNSl2tURwrXq/3tW0Y8bhr5K/ZldpBpJKk9Hp7g==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.45.0.tgz",
+      "integrity": "sha512-4BT2u4/M88h7IvoLC0yswbOPpf7UcsKWh7XXdsDdQc3aWJ1q6dDZB7jQ7tJ8WGQGgztKMcweo3bkZULgzJkECw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.34.0.tgz",
-      "integrity": "sha512-NQ/LGpaFoEYCKA0Uyg7RO04wx1MF27Jdv2S2tS81sFUO2/L0FJKyW1AQptx7SGEMIxgH9Sn4XIOdsQmLE4nGww==",
+    "node_modules/@wordpress/ui": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.12.0.tgz",
+      "integrity": "sha512-n/xfyagM90CcikLtlvNcjsFZtpt1wTpboOZPyCp9wqF6akAyJ4SUg9hXb/UA7pC8JqGe1Dg/hXJnFn/td8pvRA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.34.0"
+        "@base-ui/react": "^1.4.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/theme": "^0.12.0",
+        "clsx": "^2.1.1",
+        "tabbable": "^6.4.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/ui/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.45.0.tgz",
+      "integrity": "sha512-BqclZIPjzBYIjLqLZFihs+Ce+w+yBQuj44VYSrRDOj56AbMtwmClIUqgIVBZAe2En/2ncixTTWOZG9KluvEXfA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11765,20 +14663,20 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.19.0.tgz",
-      "integrity": "sha512-FQHFZlwFkXP/bpNjl3pXqHQN41A/W0oXWSEYnneGMc8AHjC+53ADtcaTQ2HRyWPEy4gB4C1Ovf4iSwLd8rE54Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.30.0.tgz",
+      "integrity": "sha512-8KjMTNY/6j0x2bQ799KGGfFhvlGP7OCw1ZGdNDK5q4y5ABDmVrv/dVPQywUavnFs5epQxG9vDXjN4lcD2rgtkQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/blob": "^4.34.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/preferences": "^4.34.0",
-        "@wordpress/private-apis": "^1.34.0",
-        "@wordpress/url": "^4.34.0",
+        "@wordpress/blob": "^4.45.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/url": "^4.45.0",
+        "@wordpress/vips": "^1.5.0",
         "uuid": "^9.0.1"
       },
       "engines": {
@@ -11794,6 +14692,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -11804,9 +14703,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.34.0.tgz",
-      "integrity": "sha512-gsBKwOQsn2bxcQjMnrHqKNgvSpSimP7fCOKbSoi+ALYmqybECLtadWTQJi/nNk06xzQrcX10xIhykJs3mks4yg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.45.0.tgz",
+      "integrity": "sha512-Uh29Th3EEAK/6wsBy7d9hNj2UhDzV0H7cT7xi3s4uAKOUYsIx7scawZakVRa73d3z+lnAkk0lyneIQPPosFHaQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "remove-accents": "^0.5.0"
@@ -11817,14 +14716,14 @@
       }
     },
     "node_modules/@wordpress/viewport": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.34.0.tgz",
-      "integrity": "sha512-oOMo4a8nW2yHDC1nGgPtHRTT8bLmgVA/jPb8BfKDh0YTD713QlQpkQ9+sU3+QnpODgKYHMSAEcbhJ0o7teStWg==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.45.0.tgz",
+      "integrity": "sha512-eyhtP13CxaQzLxlfhVDYvuJoEkHfPQCvUimzGT0fygi6be01g+/r27e8xjVo6C00Ot3vPzKz4Gt8RfEgGzvw1g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0"
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -11834,10 +14733,43 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/views": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/views/-/views-1.12.0.tgz",
+      "integrity": "sha512-U31d65ihTpwL236n8WDRZv8b/g1vXxqgVAYi47zDDzKDy7NRoBbQjvipxfJsXa0YKjnTkZZio+/wmVjVk0q/Ww==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/dataviews": "^14.2.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/preferences": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "dequal": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/vips": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-1.5.0.tgz",
+      "integrity": "sha512-BxTy86EHy3pXYkpJtMZGMhxipC2YQqN9xKDGlL3GZPIBjJ5A+/Xe3ZlVvGaQRc9qWz3ifOgMF4ElKpc6RK8giA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/worker-threads": "^1.5.0",
+        "wasm-vips": "^0.0.16"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/warning": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.34.0.tgz",
-      "integrity": "sha512-WemuVXjaekzCDsWbDPj/RZSy44mIjPIy35DaoJgfLcgkXMH2GRBRSomhZMkWyGatD39vdXm0nqe95LsLDqrwCg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.45.0.tgz",
+      "integrity": "sha512-NQ9tAhPdwhfceVIzWra1rbumvgAFAEDTgZlWsX880zLiq1F8JTwBouwW6wfIhA3XLcY6Yj7cBBYLa8vnNiDZDw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -11845,23 +14777,23 @@
       }
     },
     "node_modules/@wordpress/widgets": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.34.0.tgz",
-      "integrity": "sha512-hseZzlrXUDRMcgmwN2mDUL5DhlCG/RX2GJ7lNjIU/O9gM+6AOqxfmJfWdvAbkirklmQiezSfSSfPqnov1l/EZg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/widgets/-/widgets-4.45.0.tgz",
+      "integrity": "sha512-dPz7bQcrOjPhbA85+9pMpPRdx1TdEq5nGuepqiNIJfOgCSCBiBke68G+pUSJzuwrgwa7eiEE1G8hXAdHTA2CQg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.34.0",
-        "@wordpress/base-styles": "^6.10.0",
-        "@wordpress/block-editor": "^15.7.0",
-        "@wordpress/blocks": "^15.7.0",
-        "@wordpress/components": "^30.7.0",
-        "@wordpress/compose": "^7.34.0",
-        "@wordpress/core-data": "^7.34.0",
-        "@wordpress/data": "^10.34.0",
-        "@wordpress/element": "^6.34.0",
-        "@wordpress/i18n": "^6.7.0",
-        "@wordpress/icons": "^11.1.0",
-        "@wordpress/notices": "^5.34.0",
+        "@wordpress/api-fetch": "^7.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/block-editor": "^15.18.0",
+        "@wordpress/blocks": "^15.18.0",
+        "@wordpress/components": "^33.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/core-data": "^7.45.0",
+        "@wordpress/data": "^10.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/notices": "^5.45.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -11873,11 +14805,154 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/wordcount": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.34.0.tgz",
-      "integrity": "sha512-Pa/xioeKMHgE3sia0LFQC5d6O+YAio+O8ZncKbn18tZYm/mCQzOFwXWsY6MO+UjXczL+HjG5AgBW1XNVpW2M3A==",
+    "node_modules/@wordpress/widgets/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@wordpress/widgets/node_modules/@wordpress/base-styles": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
       "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/widgets/node_modules/@wordpress/components": {
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.0.0.tgz",
+      "integrity": "sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.22",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.45.0",
+        "@wordpress/base-styles": "^7.0.0",
+        "@wordpress/compose": "^7.45.0",
+        "@wordpress/date": "^5.45.0",
+        "@wordpress/deprecated": "^4.45.0",
+        "@wordpress/dom": "^4.45.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/escape-html": "^3.45.0",
+        "@wordpress/hooks": "^4.45.0",
+        "@wordpress/html-entities": "^4.45.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/icons": "^13.0.0",
+        "@wordpress/is-shallow-equal": "^5.45.0",
+        "@wordpress/keycodes": "^4.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "@wordpress/private-apis": "^1.45.0",
+        "@wordpress/rich-text": "^7.45.0",
+        "@wordpress/warning": "^3.45.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/widgets/node_modules/@wordpress/icons": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.0.0.tgz",
+      "integrity": "sha512-+CLbvNdzMUHxQK5I6gFdHb3X6EVAH6SOSIj0xtMWm6PZO+Nnf7tXHfNBuxqTnGfxT5grtfb6D3A9ZMBU+Tpv+Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/primitives": "^4.45.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/widgets/node_modules/@wordpress/keycodes": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.45.0.tgz",
+      "integrity": "sha512-N+Wp572xZovLM45cYo6HfUNTQNDfEqakAYIOcY8bUqA2iFelN6AUkNfUIkIxmrE0EqkQAQ5odES03g8ym7e1IA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.18.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/widgets/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/wordcount": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.45.0.tgz",
+      "integrity": "sha512-pv81+OANhvWSkMKD6QP429drE1GT4MQnoqAFcQItJyPSMJ58sO731Xui1wWKLkrwh9s/QhokAnyo+eRasjY7LQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/worker-threads": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.5.0.tgz",
+      "integrity": "sha512-X4jVjyy6k2cbXzrXN7tcqYDBRiEV8DfFGdbDJrglrA/yAtKKe4l+h/yjyEfjzMJQNcwxKmwzFnzkW0ZJQILFTg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "comctx": "^1.4.3"
+      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -12561,14 +15636,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -12905,6 +15981,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12935,9 +16012,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13155,30 +16232,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -13595,6 +16648,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
       "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "good-listener": "^1.2.2",
@@ -13761,6 +16815,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorjs.io": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+      "integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/color"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -13773,6 +16837,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/comctx": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.6.1.tgz",
+      "integrity": "sha512-ZMRGAYASYRdVfEoB7oxH8Nqu5Ay8I+YvAsQni+td0pYV9eww/PrtSFVyvc2JkNQyHXGDknCB4wJfxFYP6fuqZg==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -13955,6 +17025,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -15302,9 +18378,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/cwd": {
@@ -15724,6 +18800,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/depd": {
@@ -15862,7 +18939,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -15877,7 +18953,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15904,7 +18979,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -15917,9 +18991,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -15929,7 +19003,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -16137,7 +19210,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -16173,12 +19245,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
       "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
-      "license": "MIT"
-    },
-    "node_modules/err-code": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -16397,6 +19463,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -17789,9 +20856,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -18128,9 +21195,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -18388,12 +21455,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-browser-rtc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
-      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
-      "license": "MIT"
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -18542,6 +21603,12 @@
         "encoding": "^0.1.12",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -18693,6 +21760,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delegate": "^3.1.2"
@@ -19041,6 +22109,16 @@
       "integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
       "license": "MIT"
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
+      "integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -19078,6 +22156,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-react-parser": {
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.11.tgz",
+      "integrity": "sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.2",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.21"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -19089,6 +22188,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-deceiver": {
@@ -19240,6 +22370,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19395,12 +22526,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/import-locals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-locals/-/import-locals-2.0.0.tgz",
-      "integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==",
-      "license": "MIT"
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -19437,6 +22562,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -19445,6 +22571,12 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -19485,9 +22617,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20128,6 +23260,15 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isbot": {
+      "version": "5.1.40",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.40.tgz",
+      "integrity": "sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -21792,9 +24933,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.114",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
-      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "version": "0.2.99",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
+      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
       "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -24235,9 +27376,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -25349,6 +28490,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25379,6 +28521,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -25564,6 +28707,12 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -25575,9 +28724,9 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -25751,6 +28900,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -25989,6 +29139,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -26451,6 +29607,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/select-hose": {
@@ -26568,6 +29725,27 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
+      "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.4.tgz",
+      "integrity": "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
       }
     },
     "node_modules/serve-index": {
@@ -27130,35 +30308,6 @@
       "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "license": "MIT"
     },
-    "node_modules/simple-peer": {
-      "version": "9.11.1",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
-      "integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "debug": "^4.3.2",
-        "err-code": "^3.0.1",
-        "get-browser-rtc": "^1.1.0",
-        "queue-microtask": "^1.2.3",
-        "randombytes": "^2.1.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -27535,6 +30684,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -27856,6 +31006,24 @@
       "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/stylehacks": {
       "version": "6.1.1",
@@ -28417,6 +31585,12 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -28726,6 +31900,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-core": {
@@ -29573,6 +32748,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -29586,9 +32762,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -29696,6 +32872,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wasm-vips": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.16.tgz",
+      "integrity": "sha512-4/bEq8noAFt7DX3VT+Vt5AgNtnnOLwvmrDbduWfiv9AV+VYkbUU4f9Dam9e6khRqPinyClFHCqiwATTTJEiGwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.4.0"
       }
     },
     "node_modules/watchpack": {
@@ -30569,7 +33754,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -30627,30 +33812,10 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/y-indexeddb": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
-      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.74"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "yjs": "^13.0.0"
-      }
-    },
     "node_modules/y-protocols": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
-      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.85"
@@ -30665,33 +33830,6 @@
       },
       "peerDependencies": {
         "yjs": "^13.0.0"
-      }
-    },
-    "node_modules/y-webrtc": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.2.6.tgz",
-      "integrity": "sha512-1kZ4YYwksFZi8+l8mTebVX9vW6Q5MnqxMkvNU700X5dBE38usurt/JgeXSIQRpK3NwUYYb9y63Jn9FMpMH6/vA==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.42",
-        "simple-peer": "^9.11.0",
-        "y-protocols": "^1.0.6"
-      },
-      "bin": {
-        "y-webrtc-signaling": "bin/server.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "optionalDependencies": {
-        "ws": "^8.14.2"
-      },
-      "peerDependencies": {
-        "yjs": "^13.6.8"
       }
     },
     "node_modules/y18n": {
@@ -30783,9 +33921,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.27",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
-      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "version": "13.6.29",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
+      "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.99"

--- a/services/utils.ts
+++ b/services/utils.ts
@@ -15,7 +15,7 @@ import {
 } from '@wordpress/blocks';
 import { addQueryArgs } from '@wordpress/url';
 
-import type { BlockInstance, BlockVariation } from '@wordpress/blocks';
+import type { Block, BlockVariation } from '@wordpress/blocks';
 import type { BlockPattern } from '../blocks/query/types';
 
 /**
@@ -32,13 +32,13 @@ import type { BlockPattern } from '../blocks/query/types';
  *                                                the Query clients from these blocks.
  */
 export const getTransformedBlocksFromPattern = (
-  blocks: BlockInstance[],
+  blocks: Block[],
   queryBlockAttributes: Record<string, any>,
 ) => {
   const {
     namespace,
   } = queryBlockAttributes;
-  const clonedBlocks = blocks.map((block: BlockInstance) => cloneBlock(block));
+  const clonedBlocks = blocks.map((block: Block) => cloneBlock(block));
   const queryClientIds = [];
   const blocksQueue = [...clonedBlocks];
   while (blocksQueue.length > 0) {
@@ -49,7 +49,7 @@ export const getTransformedBlocksFromPattern = (
       }
       queryClientIds.push(block.clientId);
     }
-    block?.innerBlocks?.forEach((innerBlock: BlockInstance) => {
+    block?.innerBlocks?.forEach((innerBlock: Block) => {
       blocksQueue.push(innerBlock);
     });
   }
@@ -75,7 +75,6 @@ export function useBlockNameForPatterns(clientId: string, attributes: Record<str
     (select) => {
       const activeVariationName = select(
         blocksStore,
-        // @ts-expect-error
       ).getActiveBlockVariation('wp-curate/query', attributes)?.name;
 
       if (!activeVariationName) {
@@ -126,14 +125,13 @@ export function useBlockNameForPatterns(clientId: string, attributes: Record<str
 export function useScopedBlockVariations(attributes: Record<string, any>) {
   const { activeVariationName, blockVariations } = useSelect(
     (select) => {
-      // @ts-expect-error
       const { getActiveBlockVariation, getBlockVariations } = select(blocksStore);
       return {
         activeVariationName: getActiveBlockVariation(
           'wp-curate/query',
           attributes,
         )?.name,
-        blockVariations: getBlockVariations('wp-curate/query', 'block'),
+        blockVariations: getBlockVariations('wp-curate/query', 'block') ?? [],
       };
     },
     [attributes],
@@ -146,7 +144,7 @@ export function useScopedBlockVariations(attributes: Record<string, any>) {
       return blockVariations.filter(isNotConnected);
     }
     const connectedVariations = blockVariations.filter(
-      (variation: BlockVariation) => variation.attributes?.namespace?.includes(activeVariationName),
+      (variation: BlockVariation) => (variation.attributes?.namespace as string[] | undefined)?.includes(activeVariationName),
     );
     if (connectedVariations.length) {
       return connectedVariations;

--- a/services/utils.ts
+++ b/services/utils.ts
@@ -144,7 +144,9 @@ export function useScopedBlockVariations(attributes: Record<string, any>) {
       return blockVariations.filter(isNotConnected);
     }
     const connectedVariations = blockVariations.filter(
-      (variation: BlockVariation) => (variation.attributes?.namespace as string[] | undefined)?.includes(activeVariationName),
+      (variation: BlockVariation) => (
+        variation.attributes?.namespace as string[] | undefined
+      )?.includes(activeVariationName),
     );
     if (connectedVariations.length) {
       return connectedVariations;


### PR DESCRIPTION
Fixes NPM vulnerabilities that were blocking #462.

`dompurify`
`fast-uri`
`postcss`

Addresses linting and type errors as a result.