### PR TITLE
FAM-3249: Fixes the path for installing wp-graphql

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,11 @@
     }
   },
   "extra": {
+    "installer-paths": {
+      "../{$name}": [
+        "type:wordpress-plugin"
+      ]
+    },
     "wordpress-autoloader": {
       "autoload": {
         "Alley\\WP\\WP_Curate": "src"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
 
 	scanDirectories:
 		- ./vendor
-		- ./wp-content/plugins/wp-graphql
+		- ../wp-graphql
 
 	ignoreErrors:
 		- '#maybeint of function absint#'


### PR DESCRIPTION
Fixes the path for installing WP Graph QL. This came up because running PHPStan from the composer file yielded this error: 

`Path /Users/{user-dir}/broadway/www/wp-curate/wp-content/plugins/wp-curate/wp-content/plugins/wp-graphql does not exist `

And running `composer install` resulted in a new directory, `wp-content/plugins/wp-graphql` being created inside of the wp-curate plugin.