### PR TITLE
FAM-3249 Reusable Block Support

### DIFF
--- a/services/deduplicate/index.ts
+++ b/services/deduplicate/index.ts
@@ -1,4 +1,4 @@
-import { select, dispatch } from '@wordpress/data';
+import { select, dispatch, subscribe } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import type { Block } from '../../types/block';
 import recursivelyFindBlocksByName from '../recursivelyFindBlocksByName';
@@ -14,6 +14,8 @@ const curatedIds = new Map();
 
 let running = false;
 let redo = false;
+// Prevents stacking multiple subscriptions when synced patterns are pending.
+let patternSubscribeActive = false;
 
 /**
  * Checks if a post has been used already on this page. If so, return false. If not
@@ -60,9 +62,12 @@ export default {
  *
  * For reusable blocks (`core/block`), inner blocks are resolved from the block
  * editor store rather than read from `innerBlocks`, since reusable block
- * content is not nested directly on the block object.
+ * content is not nested directly on the block object. Returns the clientIds of
+ * any synced patterns whose inner blocks are not yet loaded in the store, so
+ * mainDedupe can re-run once they become available.
  */
-const getQueryBlocks = (blocks: Block[], blockNames: string[], out: Block[]) => {
+const getQueryBlocks = (blocks: Block[], blockNames: string[], out: Block[]): string[] => {
+  const unresolvedIds: string[] = [];
   blocks.forEach((block: Block) => {
     if (blockNames.includes(block.name)) {
       out.push(block);
@@ -72,7 +77,10 @@ const getQueryBlocks = (blocks: Block[], blockNames: string[], out: Block[]) => 
       // @ts-expect-error Methods not fully typed.
       const reusableInnerBlocks: Block[] = select(blockEditorStore).getBlocks(block.clientId);
       if (reusableInnerBlocks?.length) {
-        getQueryBlocks(reusableInnerBlocks, blockNames, out);
+        unresolvedIds.push(...getQueryBlocks(reusableInnerBlocks, blockNames, out));
+      } else {
+        // Inner blocks not yet loaded; will re-run mainDedupe once they are.
+        unresolvedIds.push(block.clientId);
       }
       return;
     }
@@ -80,8 +88,9 @@ const getQueryBlocks = (blocks: Block[], blockNames: string[], out: Block[]) => 
     if (!innerBlocks) {
       return;
     }
-    getQueryBlocks(innerBlocks, blockNames, out);
+    unresolvedIds.push(...getQueryBlocks(innerBlocks, blockNames, out));
   });
+  return unresolvedIds;
 };
 
 /**
@@ -132,7 +141,7 @@ export function mainDedupe() {
   } = select('core/editor').getEditedPostAttribute('meta') || {};
 
   const queryBlocks: Block[] = [];
-  getQueryBlocks(blocks, ['wp-curate/query', 'wp-curate/subquery'], queryBlocks);
+  const unresolvedPatternIds = getQueryBlocks(blocks, ['wp-curate/query', 'wp-curate/subquery'], queryBlocks);
 
   /**
    * This block of code is responsible for enforcing the unique pinned posts setting in the editor.
@@ -268,5 +277,21 @@ export function mainDedupe() {
   if (redo) {
     // Another run has been requested. Let's run it.
     mainDedupe();
+  } else if (unresolvedPatternIds.length > 0 && !patternSubscribeActive) {
+    // One or more synced patterns had inner blocks that weren't loaded yet when
+    // getQueryBlocks ran. Subscribe to the block editor store and re-run once
+    // all of them are resolved so deduplication reflects their pinned posts.
+    patternSubscribeActive = true;
+    const unsubscribe = subscribe(() => {
+      const allResolved = unresolvedPatternIds.every(
+        // @ts-expect-error Methods not fully typed.
+        (id) => (select(blockEditorStore).getBlocks(id) ?? []).length > 0,
+      );
+      if (allResolved) {
+        patternSubscribeActive = false;
+        unsubscribe();
+        mainDedupe();
+      }
+    }, blockEditorStore);
   }
 }

--- a/src/class-positioned-post-queries.php
+++ b/src/class-positioned-post-queries.php
@@ -64,7 +64,10 @@ final class Positioned_Post_Queries implements Post_Queries {
 		// Insert dynamic posts into the available slots in the map of positioned posts.
 		do {
 			if ( null === current( $out ) ) {
-				$out[ key( $out ) ] = array_shift( $backfill_ids );
+				$key = key( $out );
+				if ( ! is_null( $key ) ) {
+					$out[ $key ] = array_shift( $backfill_ids );
+				}
 			}
 		} while ( next( $out ) !== false && count( $backfill_ids ) > 0 ); // phpcs:ignore Squiz.PHP.DisallowSizeFunctionsInLoops.Found
 

--- a/src/post-ids/class-pinned-in-post-content.php
+++ b/src/post-ids/class-pinned-in-post-content.php
@@ -11,10 +11,10 @@ use Alley\WP\Legal_Object_IDs;
 use Alley\WP\Post_IDs\Post_IDs_Envelope;
 use Alley\WP\Types\Post_IDs;
 use Alley\WP\Types\Post_Query;
+use WP_Post;
 
 use function Alley\WP\match_blocks;
 
-use WP_Post;
 
 /**
  * Post IDs from pinned posts in post content.

--- a/src/post-ids/class-pinned-in-post-content.php
+++ b/src/post-ids/class-pinned-in-post-content.php
@@ -81,7 +81,10 @@ final class Pinned_In_Post_Content implements Post_IDs {
 		if ( is_array( $query_blocks ) ) {
 			foreach ( $query_blocks as $block ) {
 				if ( isset( $block['attrs']['posts'] ) && is_array( $block['attrs']['posts'] ) ) {
-					$out = array_merge( $out, $block['attrs']['posts'] );
+					$out = array_merge(
+						$out,
+						array_filter( $block['attrs']['posts'], 'is_int' ),
+					);
 				}
 			}
 		}

--- a/src/post-ids/class-pinned-in-post-content.php
+++ b/src/post-ids/class-pinned-in-post-content.php
@@ -52,7 +52,7 @@ final class Pinned_In_Post_Content implements Post_IDs {
 			}
 		}
 
-		$out = new Legal_Object_IDs( new Post_IDs_Envelope( $out ) ); // @phpstan-ignore-line argument.type
+		$out = new Legal_Object_IDs( new Post_IDs_Envelope( $out ) );
 
 		return $out->post_ids();
 	}
@@ -99,7 +99,8 @@ final class Pinned_In_Post_Content implements Post_IDs {
 
 		if ( is_array( $pattern_blocks ) ) {
 			foreach ( $pattern_blocks as $pattern_block ) {
-				$ref = (int) ( $pattern_block['attrs']['ref'] ?? 0 );
+				$ref_value = $pattern_block['attrs']['ref'] ?? 0;
+				$ref       = is_scalar( $ref_value ) && is_numeric( $ref_value ) ? (int) $ref_value : 0;
 
 				if ( ! $ref || in_array( $ref, $visited_refs, true ) ) {
 					continue;

--- a/src/post-ids/class-pinned-in-post-content.php
+++ b/src/post-ids/class-pinned-in-post-content.php
@@ -14,6 +14,8 @@ use Alley\WP\Types\Post_Query;
 
 use function Alley\WP\match_blocks;
 
+use WP_Post;
+
 /**
  * Post IDs from pinned posts in post content.
  */
@@ -39,30 +41,13 @@ final class Pinned_In_Post_Content implements Post_IDs {
 		if ( $main_query->is_singular() ) {
 			$post = $main_query->get_queried_object();
 
-			if ( $post instanceof \WP_Post ) {
+			if ( $post instanceof WP_Post ) {
 				// Unique pinned posts relies on deduplication being enabled.
 				$post_level_unique        = get_post_meta( $post->ID, 'wp_curate_unique_pinned_posts', true );
 				$post_level_deduplication = get_post_meta( $post->ID, 'wp_curate_deduplication', true );
 
 				if ( $post_level_unique && $post_level_deduplication ) {
-					$query_blocks = match_blocks(
-						$post->post_content,
-						[
-							'name'       => [ 'wp-curate/query', 'wp-curate/subquery' ],
-							'flatten'    => true,
-							'with_attrs' => 'posts',
-						],
-					);
-
-					if ( ! is_array( $query_blocks ) ) {
-						return [];
-					}
-
-					foreach ( $query_blocks as $block ) {
-						if ( isset( $block['attrs']['posts'] ) && is_array( $block['attrs']['posts'] ) ) {
-							$out = array_merge( $out, $block['attrs']['posts'] );
-						}
-					}
+					$out = $this->collect_pinned_posts( $post->post_content );
 				}
 			}
 		}
@@ -70,5 +55,67 @@ final class Pinned_In_Post_Content implements Post_IDs {
 		$out = new Legal_Object_IDs( new Post_IDs_Envelope( $out ) ); // @phpstan-ignore-line argument.type
 
 		return $out->post_ids();
+	}
+
+	/**
+	 * Collects all pinned post IDs from WP Curate blocks in the given content,
+	 * resolving synced patterns (core/block) recursively.
+	 *
+	 * @param string $content      Block content to parse.
+	 * @param int[]  $visited_refs Synced pattern post IDs already visited, to prevent infinite loops.
+	 * @return int[]
+	 */
+	private function collect_pinned_posts( string $content, array $visited_refs = [] ): array {
+		$out = [];
+
+		// Collect pinned posts from WP Curate query blocks directly in this content.
+		$query_blocks = match_blocks(
+			$content,
+			[
+				'name'       => [ 'wp-curate/query', 'wp-curate/subquery' ],
+				'flatten'    => true,
+				'with_attrs' => 'posts',
+			],
+		);
+
+		if ( is_array( $query_blocks ) ) {
+			foreach ( $query_blocks as $block ) {
+				if ( isset( $block['attrs']['posts'] ) && is_array( $block['attrs']['posts'] ) ) {
+					$out = array_merge( $out, $block['attrs']['posts'] );
+				}
+			}
+		}
+
+		// Synced patterns store their block content in the wp_block CPT, not in the
+		// post content directly, so match_blocks() won't find WP Curate blocks inside
+		// them. Resolve each pattern's ref and scan its content recursively.
+		$pattern_blocks = match_blocks(
+			$content,
+			[
+				'name'    => [ 'core/block' ],
+				'flatten' => true,
+			],
+		);
+
+		if ( is_array( $pattern_blocks ) ) {
+			foreach ( $pattern_blocks as $pattern_block ) {
+				$ref = (int) ( $pattern_block['attrs']['ref'] ?? 0 );
+
+				if ( ! $ref || in_array( $ref, $visited_refs, true ) ) {
+					continue;
+				}
+
+				$pattern_post = get_post( $ref );
+
+				if ( $pattern_post instanceof WP_Post && ! empty( $pattern_post->post_content ) ) {
+					$out = array_merge(
+						$out,
+						$this->collect_pinned_posts( $pattern_post->post_content, [ ...$visited_refs, $ref ] ),
+					);
+				}
+			}
+		}
+
+		return $out;
 	}
 }


### PR DESCRIPTION
Fixes deduplication when a WP Curate block is on the same page as one that is saved as a pattern/reusable block. 

This only works if both settings, Deduplication and Unique Pinned Posts, post settings are set to true, see line: https://github.com/alleyinteractive/wp-curate/blob/develop/src/post-ids/class-pinned-in-post-content.php#L47

Note: This is a re-do of this PR: #462 (which was approved) that I re-did so that I could separate out the NPM Audit items (#463) and the Composer items (#464) into their own PRs.