### PR TITLE
Bump alleyinteractive/block-editor-tools from 0.14.0 to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `WP Curate` will be documented in this file.
 
 Nothing yet.
 
+## 3.2.2 - 2026-06-24
+
+- Update @alleyinteractive/block-editor-tools from 0.14.0 to 0.17.0 for an updated term selector component that replaces exhaustive pagination with debounced search-as-you-type.
+
 ## 3.2.1 - 2026-06-24
 
 - Bug fix: Fix issue preventing pagination from working in core query blocks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@alleyinteractive/block-editor-tools": "^0.14.0",
+        "@alleyinteractive/block-editor-tools": "^0.17.0",
         "@types/jest": "^30.0.0",
         "@uidotdev/usehooks": "^2.4.1",
         "@wordpress/api-fetch": "^7.32.0",
@@ -66,12 +66,12 @@
       }
     },
     "node_modules/@alleyinteractive/block-editor-tools": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alleyinteractive/block-editor-tools/-/block-editor-tools-0.14.0.tgz",
-      "integrity": "sha512-GZTjxZejTAoWG9VYkYSRsM/uOM8W2csNmSrqwpuIbTpOhbWbywJjZlWQgYiY+PrIyI+3SXhHweqOJ9wHXOUx9Q==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@alleyinteractive/block-editor-tools/-/block-editor-tools-0.17.0.tgz",
+      "integrity": "sha512-Z6AEvpQWW7mzZBLX2gn7DpNNstdSJlb4O26tjLttgmlXz21ek4FWu8h9m3hDGElgjw2cZYNEhF4taTo30Tro6A==",
       "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=18.0.0 <25.0.0",
+        "node": ">=22.0.0 <26.0.0",
         "npm": ">=8.0.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "npm run check-types && npm run eslint && npm run stylelint && npm run jest"
   },
   "dependencies": {
-    "@alleyinteractive/block-editor-tools": "^0.14.0",
+    "@alleyinteractive/block-editor-tools": "^0.17.0",
     "@types/jest": "^30.0.0",
     "@uidotdev/usehooks": "^2.4.1",
     "@wordpress/api-fetch": "^7.32.0",
@@ -77,8 +77,8 @@
     "@babel/preset-env": "^7.28.5",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
-    "@types/wordpress__edit-post": "^8.4.2",
     "@types/wordpress__block-editor": "^11.5.17",
+    "@types/wordpress__edit-post": "^8.4.2",
     "@wordpress/babel-preset-default": "^8.32.0",
     "babel-jest": "^30.2.0",
     "check-node-version": "^4.2.1",

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 3.2.1
+ * Version: 3.2.2
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
- Bumps [alleyinteractive/block-editor-tools](https://github.com/alleyinteractive/alley-scripts/tree/main/packages/block-editor-tools) from 0.14.0 to 0.17.0.
- Update to version 3.2.2.