### PR TITLE
Don't attempt to read post_id from Parse.ly metadata

### DIFF
--- a/src/features/class-parsely-support.php
+++ b/src/features/class-parsely-support.php
@@ -118,15 +118,9 @@ final class Parsely_Support implements Feature {
 			}
 			$ids = array_map(
 				function ( $post ) {
-					// Check if the metadata contains post_id, if not, use the URL to get the post ID.
-					$metadata = json_decode( $post['metadata'] ?? '', true );
-					if ( is_array( $metadata ) && isset( $metadata['post_id'] ) ) {
-						$post_id = (int) $metadata['post_id'];
-					} elseif ( function_exists( 'wpcom_vip_url_to_postid' ) ) {
-						$post_id = wpcom_vip_url_to_postid( $post['url'] );
-					} else {
-						$post_id = url_to_postid( $post['url'] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
-					}
+					$post_id = function_exists( 'wpcom_vip_url_to_postid' )
+						? wpcom_vip_url_to_postid( $post['url'] )
+						: url_to_postid( $post['url'] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
 					/**
 					 * Filters the post ID derived from Parsely post object.
 					 *


### PR DESCRIPTION
## Summary

Our attempts to read `post_id` from custom metadata rely on users setting that value in the custom metadata, which most users aren't going to do, so it shouldn't be our default posture. Instead, we reverse-engineer the post ID from the URL using built-in functions, which were the fallbacks anyway, and retain the filter on the derived post ID.

This also fixes a bug where Parse.ly's API returns a value other than stringified JSON for the `metadata` key, which would throw a TypeError in the previous implementation.

Fixes #470 