### PR TITLE
Release v3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `WP Curate` will be documented in this file.
 
 Nothing yet.
 
+## 3.2.3 - 2026-07-02
+
+- Changed: Don't attempt to read `post_id` from custom Parse.ly metadata. This value is unlikely to be set on most installations.
+
 ## 3.2.2 - 2026-06-24
 
 - Update @alleyinteractive/block-editor-tools from 0.14.0 to 0.17.0 for an updated term selector component that replaces exhaustive pagination with debounced search-as-you-type.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prestylelint": "check-node-version --package",
     "pretest:watch": "check-node-version --package",
     "pretest": "check-node-version --package",
+    "release": "npx @alleyinteractive/create-release@latest",
     "start:hot": "alley-build start --hot",
     "start": "alley-build start",
     "stylelint:fix": "stylelint --fix \"**/*.scss\"",

--- a/wp-curate.php
+++ b/wp-curate.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Curate
  * Plugin URI: https://github.com/alleyinteractive/wp-curate
  * Description: Plugin to curate homepages and other landing pages
- * Version: 3.2.2
+ * Version: 3.2.3
  * Author: Alley Interactive
  * Author URI: https://github.com/alleyinteractive/wp-curate
  * Requires at least: 6.4


### PR DESCRIPTION
## Summary

Releases version 3.2.3 by bumping the version number and adding details to the changelog. Adds a new `npm run release` command to help with this process in the future.